### PR TITLE
feat(ui): comprehensive UX overhaul of Docker Desktop extension

### DIFF
--- a/scripts/test-imds-server.sh
+++ b/scripts/test-imds-server.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# Copyright 2026 Matt Miller
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Integration test: barnacle-imds-proxy + imds-server end-to-end
+#
+# Prerequisites:
+#   - Docker Desktop running with barnacle extension installed and enabled
+#   - barnacle configured to forward to http://localhost:3000
+#     (set this in the barnacle extension UI before running)
+#   - imds-server repo checked out (default: ~/repos/imdsutil/imds-server)
+#     override with: IMDS_SERVER_REPO=/path/to/imds-server bats scripts/test-imds-server.sh
+#   - Node.js available in PATH
+#
+# Usage:
+#   bats scripts/test-imds-server.sh
+
+CONTAINER_NAME="imds-server-integration-test"
+IMDS_SERVER_PORT=3000
+IMDS_SERVER_REPO="${IMDS_SERVER_REPO:-$HOME/repos/imdsutil/imds-server}"
+
+setup_file() {
+    # Verify prerequisites
+    if ! command -v node >/dev/null 2>&1; then
+        echo "node not found in PATH" >&2
+        return 1
+    fi
+
+    if [ ! -f "$IMDS_SERVER_REPO/src/index.js" ]; then
+        echo "imds-server not found at $IMDS_SERVER_REPO" >&2
+        echo "Set IMDS_SERVER_REPO=/path/to/imds-server and retry" >&2
+        return 1
+    fi
+
+    local echo_handler="$IMDS_SERVER_REPO/test/fixtures/echo-handler.sh"
+    chmod +x "$echo_handler"
+
+    # Write a temp config pointing at the echo handler
+    local config_file="$BATS_FILE_TMPDIR/imds-server.yaml"
+    cat > "$config_file" <<EOF
+port: $IMDS_SERVER_PORT
+logLevel: info
+handlers:
+  - command: $echo_handler
+    types:
+      - credentials
+EOF
+
+    # Start imds-server
+    node "$IMDS_SERVER_REPO/src/index.js" --config "$config_file" &
+    echo "$!" > "$BATS_FILE_TMPDIR/imds-server.pid"
+
+    # Wait for imds-server to be ready
+    for i in $(seq 1 10); do
+        if curl -s --max-time 2 "http://localhost:$IMDS_SERVER_PORT/latest/meta-data/" >/dev/null 2>&1 >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+    if ! curl -s --max-time 2 "http://localhost:$IMDS_SERVER_PORT/latest/meta-data/" >/dev/null 2>&1 >/dev/null 2>&1; then
+        echo "imds-server failed to start on port $IMDS_SERVER_PORT" >&2
+        return 1
+    fi
+
+    # Start a labeled container
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker run -d --rm --name "$CONTAINER_NAME" --label imds-proxy.enabled=true alpine sleep 3600 >/dev/null
+
+    # Wait for barnacle to attach IMDS networks
+    for i in $(seq 1 15); do
+        networks=$(docker inspect "$CONTAINER_NAME" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}' 2>/dev/null || echo "")
+        if echo "$networks" | grep -q 'imds_aws_gcp'; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Container was not attached to IMDS networks within 15s" >&2
+    echo "Is barnacle running and configured to forward to http://localhost:$IMDS_SERVER_PORT?" >&2
+    return 1
+}
+
+teardown_file() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    if [ -f "$BATS_FILE_TMPDIR/imds-server.pid" ]; then
+        kill "$(cat "$BATS_FILE_TMPDIR/imds-server.pid")" 2>/dev/null || true
+    fi
+}
+
+# --- reachability ---
+
+@test "credentials endpoint is reachable via 169.254.169.254" {
+    run docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 \
+        http://169.254.169.254/latest/meta-data/iam/security-credentials/test-role
+    [ "$status" -eq 0 ]
+}
+
+# --- response content ---
+
+@test "credentials response contains Code field" {
+    response=$(docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 \
+        http://169.254.169.254/latest/meta-data/iam/security-credentials/test-role)
+    echo "$response" | grep -q '"Code"'
+}
+
+@test "credentials response contains AccessKeyId field" {
+    response=$(docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 \
+        http://169.254.169.254/latest/meta-data/iam/security-credentials/test-role)
+    echo "$response" | grep -q '"AccessKeyId"'
+}
+
+@test "credentials response contains SecretAccessKey field" {
+    response=$(docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 \
+        http://169.254.169.254/latest/meta-data/iam/security-credentials/test-role)
+    echo "$response" | grep -q '"SecretAccessKey"'
+}
+
+@test "credentials response contains Expiration field" {
+    response=$(docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 \
+        http://169.254.169.254/latest/meta-data/iam/security-credentials/test-role)
+    echo "$response" | grep -q '"Expiration"'
+}
+
+# --- proxy headers ---
+
+@test "x-container-id header is forwarded to imds-server" {
+    container_id=$(docker inspect "$CONTAINER_NAME" --format '{{.Id}}')
+    response=$(docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 \
+        http://169.254.169.254/latest/meta-data/iam/security-credentials/test-role)
+    # imds-server logs the container id; check it received a non-empty request
+    [ -n "$response" ]
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -37,6 +37,8 @@ import {
   Snackbar,
   Alert,
   Link,
+  Tabs,
+  Tab,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -64,6 +66,8 @@ export function App() {
   const { client: ddClient, error: clientError } = useDockerDesktopClient();
   const service = useDockerDesktopService(ddClient);
 
+  const [activeTab, setActiveTab] = useState(0);
+
   // Container state
   const [containers, setContainers] = useState<ContainerInfo[]>([]);
   const [isLoadingContainers, setIsLoadingContainers] = useState(false);
@@ -74,12 +78,7 @@ export function App() {
   const [snackbarMessage, setSnackbarMessage] = useState('');
   const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'error'>('success');
 
-  // App metadata
-  const [appDescription, setAppDescription] = useState('');
-
   // Track mount status to prevent state updates after unmount during async operations
-  // This avoids "Can't perform a React state update on an unmounted component" warnings
-  // during container polling
   const isMountedRef = useRef(false);
   // Only show the loading skeleton on the first fetch, not on background poll refreshes
   const hasLoadedOnceRef = useRef(false);
@@ -135,7 +134,6 @@ export function App() {
 
     loadContainers();
 
-    // Poll more frequently for faster updates
     const interval = setInterval(loadContainers, CONTAINER_POLL_INTERVAL_MS);
 
     return () => {
@@ -143,19 +141,6 @@ export function App() {
       clearInterval(interval);
     };
   }, [ddClient, loadContainers]);
-
-  useEffect(() => {
-    fetch('./description.json')
-      .then(res => res.json())
-      .then(data => {
-        if (data.description) {
-          setAppDescription(data.description);
-        }
-      })
-      .catch(() => {
-        // Fail silently if description.json can't be loaded
-      });
-  }, []);
 
   const copyToClipboard = (text: string, label: string) => {
     if (!navigator.clipboard || !navigator.clipboard.writeText) {
@@ -188,8 +173,9 @@ export function App() {
   };
 
   return (
-    <Stack spacing={3} sx={{ pt: 2, pr: 2, pb: 2, pl: 0 }}>
-      <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+    <Box sx={{ height: '100vh', overflow: 'hidden', display: 'flex', flexDirection: 'column', pt: 0, pr: 1, pb: 3, pl: 0 }}>
+      {/* Header */}
+      <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
         <Stack direction="row" spacing={2} alignItems="center">
           <Box
             component="img"
@@ -211,52 +197,66 @@ export function App() {
         </Link>
       </Stack>
 
-      <Stack spacing={1.5}>
-        <Typography variant="body1">
-          {appDescription}
-        </Typography>
-      </Stack>
+      {/* Tabs */}
+      <Tabs
+        value={activeTab}
+        onChange={(_e, newValue: number) => setActiveTab(newValue)}
+        sx={{ mb: 1.5, borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label="Containers" />
+        <Tab label="Settings" />
+      </Tabs>
 
-      <SettingsForm ddClient={ddClient} service={service} showSnackbar={showSnackbar} />
-
-      <Stack spacing={2}>
-        <Typography variant="body1">
-          Add the following label to a container to enable IMDS proxying for it:
-        </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Box
-            component="code"
-            sx={{
-              px: 1,
-              py: 0.5,
-              borderRadius: 0.5,
-              bgcolor: 'action.hover',
-              border: '1px solid',
-              borderColor: 'divider',
-              fontFamily: 'monospace',
-              fontSize: '0.875rem',
-            }}
-          >
-            {IMDS_PROXY_ENABLED_LABEL}
-          </Box>
-          <Tooltip title="Copy label">
-            <IconButton
-              size="small"
-              aria-label="Copy label to clipboard"
-              onClick={() => copyToClipboard(IMDS_PROXY_ENABLED_LABEL, 'label')}
+      {/* Containers tab */}
+      {activeTab === 0 && (
+        <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+          <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+            <Typography variant="body2">
+              Add the following label to a container to enable IMDS proxying:
+            </Typography>
+            <Box
+              component="code"
+              sx={{
+                px: 1,
+                py: 0.25,
+                borderRadius: 0.5,
+                bgcolor: 'action.hover',
+                border: '1px solid',
+                borderColor: 'divider',
+                fontFamily: 'monospace',
+                fontSize: '0.875rem',
+                whiteSpace: 'nowrap',
+              }}
             >
-              <ContentCopyIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
+              {IMDS_PROXY_ENABLED_LABEL}
+            </Box>
+            <Tooltip title="Copy label">
+              <IconButton
+                size="small"
+                aria-label="Copy label to clipboard"
+                onClick={() => copyToClipboard(IMDS_PROXY_ENABLED_LABEL, 'label')}
+              >
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+
+          <ContainersTable
+            containers={containers}
+            isLoading={isLoadingContainers}
+            error={containersError}
+            onCopyToClipboard={copyToClipboard}
+            onRetry={loadContainers}
+          />
         </Box>
-        <ContainersTable
-          containers={containers}
-          isLoading={isLoadingContainers}
-          error={containersError}
-          onCopyToClipboard={copyToClipboard}
-          onRetry={loadContainers}
-        />
-      </Stack>
+      )}
+
+      {/* Settings tab */}
+      {activeTab === 1 && (
+        <Box sx={{ maxWidth: 600 }}>
+          <SettingsForm ddClient={ddClient} service={service} showSnackbar={showSnackbar} />
+        </Box>
+      )}
 
       <Snackbar
         open={snackbarOpen}
@@ -268,6 +268,6 @@ export function App() {
           {snackbarMessage}
         </Alert>
       </Snackbar>
-    </Stack>
+    </Box>
   );
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -81,6 +81,8 @@ export function App() {
   // This avoids "Can't perform a React state update on an unmounted component" warnings
   // during container polling
   const isMountedRef = useRef(false);
+  // Only show the loading skeleton on the first fetch, not on background poll refreshes
+  const hasLoadedOnceRef = useRef(false);
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error') => {
     setSnackbarMessage(message);
@@ -93,12 +95,15 @@ export function App() {
       return;
     }
 
-    setIsLoadingContainers(true);
+    if (!hasLoadedOnceRef.current) {
+      setIsLoadingContainers(true);
+    }
     setContainersError(null);
 
     try {
       const result = await service.getContainers();
       if (isContainersResponse(result) && isMountedRef.current) {
+        hasLoadedOnceRef.current = true;
         setContainers(result);
       } else if (isMountedRef.current) {
         showSnackbar('Unexpected containers response format', 'error');

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,7 +21,17 @@ import {
   SNACKBAR_AUTO_HIDE_DURATION_MS,
   GITHUB_REPO_URL,
   IMDS_PROXY_ENABLED_LABEL,
+  BACKEND_REQUEST_TIMEOUT_MS,
 } from './constants';
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Request timed out')), ms)
+    ),
+  ]);
+}
 import {
   ContainerInfo,
   isContainersResponse,
@@ -39,6 +49,14 @@ import {
   Link,
   Tabs,
   Tab,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -67,11 +85,12 @@ export function App() {
   const service = useDockerDesktopService(ddClient);
 
   const [activeTab, setActiveTab] = useState(0);
+  const [proxyUnreachable, setProxyUnreachable] = useState(false);
+  const [proxyHelpOpen, setProxyHelpOpen] = useState(false);
 
   // Container state
   const [containers, setContainers] = useState<ContainerInfo[]>([]);
   const [isLoadingContainers, setIsLoadingContainers] = useState(false);
-  const [containersError, setContainersError] = useState<string | null>(null);
 
   // Snackbar notification state
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -97,23 +116,23 @@ export function App() {
     if (!hasLoadedOnceRef.current) {
       setIsLoadingContainers(true);
     }
-    setContainersError(null);
-
     try {
-      const result = await service.getContainers();
+      const result = await withTimeout(service.getContainers(), BACKEND_REQUEST_TIMEOUT_MS);
       if (isContainersResponse(result) && isMountedRef.current) {
         hasLoadedOnceRef.current = true;
         setContainers(result);
+        setProxyUnreachable(false);
       } else if (isMountedRef.current) {
         showSnackbar('Unexpected containers response format', 'error');
       }
     } catch (error) {
       console.error('Failed to load containers:', error);
       if (isMountedRef.current) {
-        showSnackbar('Failed to load containers', 'error');
-        setContainersError('Failed to refresh containers');
+        setProxyUnreachable(true);
       }
     } finally {
+      // Mark as attempted regardless of outcome so we never show the skeleton again
+      hasLoadedOnceRef.current = true;
       if (isMountedRef.current) {
         setIsLoadingContainers(false);
       }
@@ -244,9 +263,9 @@ export function App() {
           <ContainersTable
             containers={containers}
             isLoading={isLoadingContainers}
-            error={containersError}
             onCopyToClipboard={copyToClipboard}
-            onRetry={loadContainers}
+            proxyUnreachable={proxyUnreachable}
+            onProxyHelp={() => setProxyHelpOpen(true)}
           />
         </Box>
       )}
@@ -254,9 +273,63 @@ export function App() {
       {/* Settings tab */}
       {activeTab === 1 && (
         <Box sx={{ maxWidth: 600 }}>
-          <SettingsForm ddClient={ddClient} service={service} showSnackbar={showSnackbar} />
+          <SettingsForm
+            ddClient={ddClient}
+            service={service}
+            showSnackbar={showSnackbar}
+            proxyUnreachable={proxyUnreachable}
+            onProxyHelp={() => setProxyHelpOpen(true)}
+          />
         </Box>
       )}
+
+      <Dialog open={proxyHelpOpen} onClose={() => setProxyHelpOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Extension backend not responding</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 1.5 }}>
+            The Barnacle controller is not responding, so the container list may be outdated.
+            The IMDS proxy runs separately and may still be proxying IMDS traffic correctly.
+            To restore full functionality, try the following steps:
+          </Typography>
+          <List dense disablePadding>
+            <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
+              <ListItemText
+                primary="1. Restart the extension"
+                secondary="In Docker Desktop, open the Extensions Marketplace, find Barnacle, and click Disable then Enable."
+              />
+            </ListItem>
+            <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
+              <ListItemText
+                primary="2. Restart Docker Desktop"
+                secondary="Quit and relaunch Docker Desktop. This restarts all extension services."
+              />
+            </ListItem>
+            <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
+              <ListItemText
+                primary="3. Still not working?"
+                secondary={
+                  <Link
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      if (ddClient?.host?.openExternal) {
+                        ddClient.host.openExternal(`${GITHUB_REPO_URL}#troubleshooting`);
+                      } else {
+                        window.open(`${GITHUB_REPO_URL}#troubleshooting`, '_blank', 'noopener,noreferrer');
+                      }
+                    }}
+                  >
+                    View the troubleshooting guide
+                  </Link>
+                }
+              />
+            </ListItem>
+          </List>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setProxyHelpOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
 
       <Snackbar
         open={snackbarOpen}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -188,7 +188,7 @@ export function App() {
   };
 
   return (
-    <Stack spacing={3} sx={{ p: 2 }}>
+    <Stack spacing={3} sx={{ pt: 2, pr: 2, pb: 2, pl: 0 }}>
       <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
         <Stack direction="row" spacing={2} alignItems="center">
           <Box

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -215,37 +215,41 @@ export function App() {
       <SettingsForm ddClient={ddClient} service={service} showSnackbar={showSnackbar} />
 
       <Stack spacing={2}>
-        <Typography variant="body1" sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
-          Add a
+        <Typography variant="body1">
+          Add the following label to a container to enable IMDS proxying for it:
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Box
             component="code"
             sx={{
-              px: 0.5,
-              py: 0.25,
+              px: 1,
+              py: 0.5,
               borderRadius: 0.5,
               bgcolor: 'action.hover',
+              border: '1px solid',
+              borderColor: 'divider',
               fontFamily: 'monospace',
+              fontSize: '0.875rem',
             }}
           >
             {IMDS_PROXY_ENABLED_LABEL}
-            <Tooltip title="Copy label">
-              <IconButton
-                size="small"
-                aria-label="Copy label text"
-                onClick={() => copyToClipboard(IMDS_PROXY_ENABLED_LABEL, 'label')}
-                sx={{ padding: '2px' }}
-              >
-                <ContentCopyIcon fontSize="inherit" sx={{ fontSize: '0.75rem' }} />
-              </IconButton>
-            </Tooltip>
           </Box>
-          label to containers to enable IMDS proxying for them.
-        </Typography>
+          <Tooltip title="Copy label">
+            <IconButton
+              size="small"
+              aria-label="Copy label to clipboard"
+              onClick={() => copyToClipboard(IMDS_PROXY_ENABLED_LABEL, 'label')}
+            >
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
         <ContainersTable
           containers={containers}
           isLoading={isLoadingContainers}
           error={containersError}
           onCopyToClipboard={copyToClipboard}
+          onRetry={loadContainers}
         />
       </Stack>
 

--- a/ui/src/__tests__/app.test.tsx
+++ b/ui/src/__tests__/app.test.tsx
@@ -59,7 +59,7 @@ describe('App', () => {
 
     await waitFor(
       () => {
-        expect(screen.getByText('Failed to refresh containers')).toBeTruthy();
+        expect(screen.getByText(/Extension backend not responding/)).toBeTruthy();
       },
       { timeout: 3000 }
     );

--- a/ui/src/__tests__/app.test.tsx
+++ b/ui/src/__tests__/app.test.tsx
@@ -97,7 +97,7 @@ describe('App', () => {
     render(<App />);
 
     // Find and click the label copy button
-    const copyButton = await screen.findByRole('button', { name: /copy label text/i });
+    const copyButton = await screen.findByRole('button', { name: /copy label to clipboard/i });
     copyButton.click();
 
     expect(mockWriteText).toHaveBeenCalledWith('imds-proxy.enabled=true');
@@ -125,7 +125,7 @@ describe('App', () => {
     render(<App />);
 
     // Find and click the label copy button
-    const copyButton = await screen.findByRole('button', { name: /copy label text/i });
+    const copyButton = await screen.findByRole('button', { name: /copy label to clipboard/i });
     copyButton.click();
 
     await waitFor(() => {
@@ -148,7 +148,7 @@ describe('App', () => {
     render(<App />);
 
     // Find and click the label copy button
-    const copyButton = await screen.findByRole('button', { name: /copy label text/i });
+    const copyButton = await screen.findByRole('button', { name: /copy label to clipboard/i });
 
     // Wrap click in act() since clipboard check causes synchronous state update
     act(() => {

--- a/ui/src/__tests__/containersTable.test.tsx
+++ b/ui/src/__tests__/containersTable.test.tsx
@@ -39,9 +39,6 @@ const mockContainers = [
   }),
 ];
 
-const DEFAULT_PAGE_SIZE = 10;
-const PAGE_SIZE_25 = 25;
-const PAGINATION_SET_SIZE = 15;
 const LARGE_SET_SIZE = 30;
 const ALPHA_CONTAINER_ID = '111222333444555666777888999000aaabbb';
 
@@ -107,39 +104,8 @@ describe('ContainersTable', () => {
     expect(rows[5].textContent).toContain('xyz987wvu654');
   });
 
-  it('paginates containers correctly', () => {
+  it('shows all containers without pagination', () => {
     const mockCallback = vi.fn();
-
-    // Create 15 containers to test pagination
-    const manyContainers = createMockContainers(PAGINATION_SET_SIZE);
-
-    render(
-      <ContainersTable
-        containers={manyContainers}
-        isLoading={false}
-        error={null}
-        onCopyToClipboard={mockCallback}
-      />
-    );
-
-    // Default is 10 per page, should show container-0 through container-9
-    // Each data row has a sibling expansion row, so total = 1 header + N*2 rows
-    let rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(DEFAULT_PAGE_SIZE * 2 + 1);
-
-    // Click next page
-    const nextButton = screen.getByRole('button', { name: /next page/i });
-    fireEvent.click(nextButton);
-
-    // Should now show remaining 5 containers (sorted alphabetically: container-5 through container-9)
-    rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength((PAGINATION_SET_SIZE - DEFAULT_PAGE_SIZE) * 2 + 1);
-    expect(rows[1].textContent).toContain('container-5');
-  });
-
-  it('changes rows per page correctly', () => {
-    const mockCallback = vi.fn();
-
     const manyContainers = createMockContainers(LARGE_SET_SIZE);
 
     render(
@@ -151,18 +117,10 @@ describe('ContainersTable', () => {
       />
     );
 
-    // Default is 10 per page; each data row has a sibling expansion row
-    let rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(DEFAULT_PAGE_SIZE * 2 + 1);
-
-    // Change to 25 per page
-    const rowsPerPageSelect = screen.getByRole('combobox');
-    fireEvent.mouseDown(rowsPerPageSelect);
-    const option25 = screen.getByRole('option', { name: String(PAGE_SIZE_25) });
-    fireEvent.click(option25);
-
-    rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(PAGE_SIZE_25 * 2 + 1);
+    // All containers rendered at once: 1 header + N data rows + N expansion rows
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(LARGE_SET_SIZE * 2 + 1);
+    expect(screen.getByText(`Showing ${LARGE_SET_SIZE} items`)).toBeDefined();
   });
 
   it('copy button triggers callback without selecting row', () => {

--- a/ui/src/__tests__/containersTable.test.tsx
+++ b/ui/src/__tests__/containersTable.test.tsx
@@ -49,7 +49,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={mockContainers}
         isLoading={false}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
@@ -68,7 +67,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={mockContainers}
         isLoading={false}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
@@ -88,7 +86,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={mockContainers}
         isLoading={false}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
@@ -112,7 +109,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={manyContainers}
         isLoading={false}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
@@ -129,7 +125,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={mockContainers}
         isLoading={false}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
@@ -153,7 +148,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={mockContainers}
         isLoading={false}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
@@ -176,44 +170,12 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={[]}
         isLoading={true}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );
 
     // Skeleton renders as a div with no text — just verify the table is not shown
     expect(screen.queryByRole('table')).toBeNull();
-  });
-
-  it('displays error message when error is set', () => {
-    const mockCallback = vi.fn();
-    const errorMessage = 'Failed to fetch containers';
-
-    render(
-      <ContainersTable
-        containers={[]}
-        isLoading={false}
-        error={errorMessage}
-        onCopyToClipboard={mockCallback}
-      />
-    );
-
-   expect(screen.getByText(errorMessage)).toBeDefined();
-  });
-
-  it('displays empty state message when no containers are tracked', () => {
-    const mockCallback = vi.fn();
-
-    render(
-      <ContainersTable
-        containers={[]}
-        isLoading={false}
-        error={null}
-        onCopyToClipboard={mockCallback}
-      />
-    );
-
-    expect(screen.getByText(/No containers with the IMDS proxy label are running/)).toBeDefined();
   });
 
   it('does not show loading message when loading but has containers', () => {
@@ -223,7 +185,6 @@ describe('ContainersTable', () => {
       <ContainersTable
         containers={mockContainers}
         isLoading={true}
-        error={null}
         onCopyToClipboard={mockCallback}
       />
     );

--- a/ui/src/__tests__/containersTable.test.tsx
+++ b/ui/src/__tests__/containersTable.test.tsx
@@ -58,10 +58,11 @@ describe('ContainersTable', () => {
     );
 
     const rows = screen.getAllByRole('row');
-    // Skip header row (index 0)
+    // Skip header row (index 0); each data row is followed by a collapsed expansion row,
+    // so data rows are at odd indices: 1, 3, 5, ...
     expect(rows[1].textContent).toContain('alpha-container');
-    expect(rows[2].textContent).toContain('beta-container');
-    expect(rows[3].textContent).toContain('zebra-container');
+    expect(rows[3].textContent).toContain('beta-container');
+    expect(rows[5].textContent).toContain('zebra-container');
   });
 
   it('sorts by name descending when clicking name column twice', () => {
@@ -80,8 +81,8 @@ describe('ContainersTable', () => {
 
     const rows = screen.getAllByRole('row');
     expect(rows[1].textContent).toContain('zebra-container');
-    expect(rows[2].textContent).toContain('beta-container');
-    expect(rows[3].textContent).toContain('alpha-container');
+    expect(rows[3].textContent).toContain('beta-container');
+    expect(rows[5].textContent).toContain('alpha-container');
   });
 
   it('sorts by container ID when clicking ID column', () => {
@@ -102,8 +103,8 @@ describe('ContainersTable', () => {
     // IDs start with: "111...", "abc...", "xyz..."
     // Ascending alphabetically: "111" < "abc" < "xyz"
     expect(rows[1].textContent).toContain('111222333444');
-    expect(rows[2].textContent).toContain('abc123def456');
-    expect(rows[3].textContent).toContain('xyz987wvu654');
+    expect(rows[3].textContent).toContain('abc123def456');
+    expect(rows[5].textContent).toContain('xyz987wvu654');
   });
 
   it('paginates containers correctly', () => {
@@ -122,8 +123,9 @@ describe('ContainersTable', () => {
     );
 
     // Default is 10 per page, should show container-0 through container-9
+    // Each data row has a sibling expansion row, so total = 1 header + N*2 rows
     let rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(DEFAULT_PAGE_SIZE + 1); // 1 header + default data rows
+    expect(rows).toHaveLength(DEFAULT_PAGE_SIZE * 2 + 1);
 
     // Click next page
     const nextButton = screen.getByRole('button', { name: /next page/i });
@@ -131,7 +133,7 @@ describe('ContainersTable', () => {
 
     // Should now show remaining 5 containers (sorted alphabetically: container-5 through container-9)
     rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(PAGINATION_SET_SIZE - DEFAULT_PAGE_SIZE + 1);
+    expect(rows).toHaveLength((PAGINATION_SET_SIZE - DEFAULT_PAGE_SIZE) * 2 + 1);
     expect(rows[1].textContent).toContain('container-5');
   });
 
@@ -149,9 +151,9 @@ describe('ContainersTable', () => {
       />
     );
 
-    // Default is 10 per page
+    // Default is 10 per page; each data row has a sibling expansion row
     let rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(DEFAULT_PAGE_SIZE + 1); // 1 header + default data rows
+    expect(rows).toHaveLength(DEFAULT_PAGE_SIZE * 2 + 1);
 
     // Change to 25 per page
     const rowsPerPageSelect = screen.getByRole('combobox');
@@ -160,7 +162,7 @@ describe('ContainersTable', () => {
     fireEvent.click(option25);
 
     rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(PAGE_SIZE_25 + 1); // 1 header + 25 data rows
+    expect(rows).toHaveLength(PAGE_SIZE_25 * 2 + 1);
   });
 
   it('copy button triggers callback without selecting row', () => {

--- a/ui/src/__tests__/containersTable.test.tsx
+++ b/ui/src/__tests__/containersTable.test.tsx
@@ -223,7 +223,8 @@ describe('ContainersTable', () => {
       />
     );
 
-    expect(screen.getByText('Loading containers...')).toBeDefined();
+    // Skeleton renders as a div with no text — just verify the table is not shown
+    expect(screen.queryByRole('table')).toBeNull();
   });
 
   it('displays error message when error is set', () => {
@@ -254,7 +255,7 @@ describe('ContainersTable', () => {
       />
     );
 
-    expect(screen.getByText('No tracked containers found')).toBeDefined();
+    expect(screen.getByText(/No containers with the IMDS proxy label are running/)).toBeDefined();
   });
 
   it('does not show loading message when loading but has containers', () => {

--- a/ui/src/__tests__/settingsForm.test.tsx
+++ b/ui/src/__tests__/settingsForm.test.tsx
@@ -46,7 +46,7 @@ describe('SettingsForm', () => {
     );
 
     await waitFor(() => {
-      const input = screen.getByLabelText(/URL of your IMDS server/i) as HTMLInputElement;
+      const input = screen.getByLabelText(/IMDS server URL/i) as HTMLInputElement;
       expect(input.value).toBe(SETTINGS_URL);
     });
 
@@ -69,7 +69,7 @@ describe('SettingsForm', () => {
     );
 
     await waitFor(() => {
-      const input = screen.getByLabelText(/URL of your IMDS server/i) as HTMLInputElement;
+      const input = screen.getByLabelText(/IMDS server URL/i) as HTMLInputElement;
       expect(input.value).toBe(LOCAL_URL);
     });
 
@@ -92,7 +92,7 @@ describe('SettingsForm', () => {
       />
     );
 
-    const input = await screen.findByLabelText(/URL of your IMDS server/i);
+    const input = await screen.findByLabelText(/IMDS server URL/i);
     fireEvent.change(input, { target: { value: '' } });
 
     fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
@@ -118,7 +118,7 @@ describe('SettingsForm', () => {
       />
     );
 
-    const input = await screen.findByLabelText(/URL of your IMDS server/i);
+    const input = await screen.findByLabelText(/IMDS server URL/i);
 
     vi.useFakeTimers();
     fireEvent.change(input, { target: { value: 'http://new' } });

--- a/ui/src/__tests__/settingsForm.test.tsx
+++ b/ui/src/__tests__/settingsForm.test.tsx
@@ -73,8 +73,7 @@ describe('SettingsForm', () => {
       expect(input.value).toBe(LOCAL_URL);
     });
 
-    expect(showSnackbar).toHaveBeenNthCalledWith(1, 'Failed to load settings from backend', 'error');
-    expect(showSnackbar).toHaveBeenNthCalledWith(2, 'Backend unavailable, using local settings', 'error');
+    expect(showSnackbar).not.toHaveBeenCalled();
   });
 
   it('validates required URL before saving', async () => {

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -29,7 +29,6 @@ import {
   Stack,
   Collapse,
   Box,
-  Button,
   Skeleton,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -42,17 +41,17 @@ import { cleanContainerName } from '../utils/containerUtils';
 interface ContainersTableProps {
   containers: ContainerInfo[];
   isLoading: boolean;
-  error: string | null;
   onCopyToClipboard: (text: string, label: string) => void;
-  onRetry?: () => void;
+  proxyUnreachable?: boolean;
+  onProxyHelp?: () => void;
 }
 
 export function ContainersTable({
   containers,
   isLoading,
-  error,
   onCopyToClipboard,
-  onRetry,
+  proxyUnreachable,
+  onProxyHelp,
 }: ContainersTableProps) {
   const [expandedContainer, setExpandedContainer] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<'name' | 'id'>('name');
@@ -85,43 +84,18 @@ export function ContainersTable({
     onCopyToClipboard(text, label);
   };
 
-  if (isLoading && containers.length === 0) {
-    return (
-      <Stack spacing={1}>
-        <Skeleton variant="rectangular" height={40} />
-        <Skeleton variant="rectangular" height={40} />
-        <Skeleton variant="rectangular" height={40} />
-      </Stack>
-    );
-  }
+  const renderContent = () => {
+    if (isLoading && containers.length === 0) {
+      return (
+        <Stack spacing={1}>
+          <Skeleton variant="rectangular" height={40} />
+          <Skeleton variant="rectangular" height={40} />
+          <Skeleton variant="rectangular" height={40} />
+        </Stack>
+      );
+    }
 
-  if (error) {
     return (
-      <Stack direction="row" alignItems="center" spacing={1}>
-        <Typography variant="body1" color="error">
-          {error}
-        </Typography>
-        {onRetry && (
-          <Button size="small" variant="outlined" color="error" onClick={onRetry}>
-            Retry
-          </Button>
-        )}
-      </Stack>
-    );
-  }
-
-  if (containers.length === 0) {
-    return (
-      <Typography variant="body1" color="text.secondary">
-        No containers with the IMDS proxy label are running. Start a container with the label above
-        to see it here.
-      </Typography>
-    );
-  }
-
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
-      <Typography variant="subtitle1" sx={{ mb: 1 }}>Enabled for these containers</Typography>
       <TableContainer component={Paper} variant="outlined" sx={{ flex: 1, overflow: 'auto' }}>
         <Table size="small" stickyHeader>
           <TableHead>
@@ -295,9 +269,32 @@ export function ContainersTable({
           </TableBody>
         </Table>
       </TableContainer>
-      <Typography variant="body2" color="text.secondary" align="right" sx={{ mt: 0.5 }}>
-        Showing {containers.length} {containers.length === 1 ? 'item' : 'items'}
-      </Typography>
+    );
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+      <Typography variant="subtitle1" sx={{ mb: 1 }}>Enabled for these containers</Typography>
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        {renderContent()}
+      </Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 0.5 }}>
+        <Box>
+          {proxyUnreachable && (
+            <Typography
+              variant="body2"
+              color="error"
+              onClick={onProxyHelp}
+              sx={{ cursor: onProxyHelp ? 'pointer' : 'default', textDecoration: onProxyHelp ? 'underline' : 'none' }}
+            >
+              Extension backend not responding — list may be outdated
+            </Typography>
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          Showing {containers.length} {containers.length === 1 ? 'item' : 'items'}
+        </Typography>
+      </Stack>
     </Box>
   );
 }

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -28,8 +28,12 @@ import {
   Typography,
   TablePagination,
   Stack,
+  Collapse,
+  Box,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { ContainerInfo } from '../types';
 import { CONTAINER_ID_DISPLAY_LENGTH } from '../constants';
 import { cleanContainerName } from '../utils/containerUtils';
@@ -47,7 +51,7 @@ export function ContainersTable({
   error,
   onCopyToClipboard,
 }: ContainersTableProps) {
-  const [selectedContainer, setSelectedContainer] = useState<string | null>(null);
+  const [expandedContainer, setExpandedContainer] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<'name' | 'id'>('name');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [page, setPage] = useState(0);
@@ -97,8 +101,12 @@ export function ContainersTable({
     setPage(0);
   };
 
+  const handleRowClick = (containerId: string) => {
+    setExpandedContainer((prev) => (prev === containerId ? null : containerId));
+  };
+
   const handleCopyClick = (text: string, label: string, event: React.MouseEvent) => {
-    event.stopPropagation(); // Prevent row selection when clicking copy button
+    event.stopPropagation(); // Prevent row expansion when clicking copy button
     onCopyToClipboard(text, label);
   };
 
@@ -152,93 +160,151 @@ export function ContainersTable({
                 </TableSortLabel>
               </TableCell>
               <TableCell>Networks</TableCell>
+              <TableCell padding="checkbox" />
             </TableRow>
           </TableHead>
           <TableBody>
             {paginatedContainers.map((container) => {
               const displayName = cleanContainerName(container.name);
+              const isExpanded = expandedContainer === container.containerId;
+              const sortedLabels = Object.entries(container.labels).sort(([a], [b]) =>
+                a.localeCompare(b),
+              );
               return (
-                <TableRow
-                  key={container.containerId}
-                  hover
-                  selected={selectedContainer === container.containerId}
-                  onClick={() => setSelectedContainer(container.containerId)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault();
-                      setSelectedContainer(container.containerId);
-                    }
-                  }}
-                  tabIndex={0}
-                  sx={{
-                    cursor: 'pointer',
-                    '& .copy-button': {
-                      opacity: 0,
-                      pointerEvents: 'none',
-                      transition: 'opacity 120ms ease-in-out',
-                    },
-                    '&:hover .copy-button': {
-                      opacity: 1,
-                      pointerEvents: 'auto',
-                    },
-                    '&:focus-within .copy-button': {
-                      opacity: 1,
-                      pointerEvents: 'auto',
-                    },
-                  }}
-                >
-                  <TableCell>
-                    <Stack direction="row" alignItems="center" spacing={0.5}>
-                      <Typography variant="body1">{displayName}</Typography>
-                      <Tooltip title="Copy name">
-                        <IconButton
-                          size="small"
-                          aria-label={`Copy container name ${displayName}`}
-                          onClick={(e) => handleCopyClick(displayName, 'container name', e)}
-                          className="copy-button"
-                          sx={{ padding: '2px' }}
-                        >
-                          <ContentCopyIcon fontSize="inherit" sx={{ fontSize: '0.75rem' }} />
-                        </IconButton>
-                      </Tooltip>
-                    </Stack>
-                  </TableCell>
-                  <TableCell>
-                    <Stack direction="row" alignItems="center" spacing={0.5}>
-                      <Typography
-                        variant="body1"
-                        sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
-                      >
-                        {container.containerId.substring(0, CONTAINER_ID_DISPLAY_LENGTH)}
-                      </Typography>
-                      <Tooltip title="Copy full ID">
-                        <IconButton
-                          size="small"
-                          aria-label={`Copy container id ${container.containerId}`}
-                          onClick={(e) => handleCopyClick(container.containerId, 'container ID', e)}
-                          className="copy-button"
-                          sx={{ padding: '2px' }}
-                        >
-                          <ContentCopyIcon fontSize="inherit" sx={{ fontSize: '0.75rem' }} />
-                        </IconButton>
-                      </Tooltip>
-                    </Stack>
-                  </TableCell>
-                  <TableCell>
-                    <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                      {[...container.networks]
-                        .sort((a, b) => a.networkName.localeCompare(b.networkName))
-                        .map((network) => (
-                          <Chip
-                            key={network.networkId}
-                            label={network.networkName}
+                <React.Fragment key={container.containerId}>
+                  <TableRow
+                    hover
+                    selected={isExpanded}
+                    onClick={() => handleRowClick(container.containerId)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        handleRowClick(container.containerId);
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-expanded={isExpanded}
+                    sx={{
+                      cursor: 'pointer',
+                      '& .copy-button': {
+                        opacity: 0,
+                        pointerEvents: 'none',
+                        transition: 'opacity 120ms ease-in-out',
+                      },
+                      '&:hover .copy-button': {
+                        opacity: 1,
+                        pointerEvents: 'auto',
+                      },
+                      '&:focus-within .copy-button': {
+                        opacity: 1,
+                        pointerEvents: 'auto',
+                      },
+                    }}
+                  >
+                    <TableCell>
+                      <Stack direction="row" alignItems="center" spacing={0.5}>
+                        <Typography variant="body1">{displayName}</Typography>
+                        <Tooltip title="Copy name">
+                          <IconButton
                             size="small"
-                            variant="outlined"
-                          />
-                        ))}
-                    </Stack>
-                  </TableCell>
-                </TableRow>
+                            aria-label={`Copy container name ${displayName}`}
+                            onClick={(e) => handleCopyClick(displayName, 'container name', e)}
+                            className="copy-button"
+                            sx={{ padding: '2px' }}
+                          >
+                            <ContentCopyIcon fontSize="inherit" sx={{ fontSize: '0.75rem' }} />
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      <Stack direction="row" alignItems="center" spacing={0.5}>
+                        <Typography
+                          variant="body1"
+                          sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
+                        >
+                          {container.containerId.substring(0, CONTAINER_ID_DISPLAY_LENGTH)}
+                        </Typography>
+                        <Tooltip title="Copy full ID">
+                          <IconButton
+                            size="small"
+                            aria-label={`Copy container id ${container.containerId}`}
+                            onClick={(e) =>
+                              handleCopyClick(container.containerId, 'container ID', e)
+                            }
+                            className="copy-button"
+                            sx={{ padding: '2px' }}
+                          >
+                            <ContentCopyIcon fontSize="inherit" sx={{ fontSize: '0.75rem' }} />
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                        {[...container.networks]
+                          .sort((a, b) => a.networkName.localeCompare(b.networkName))
+                          .map((network) => (
+                            <Chip
+                              key={network.networkId}
+                              label={network.networkName}
+                              size="small"
+                              variant="outlined"
+                            />
+                          ))}
+                      </Stack>
+                    </TableCell>
+                    <TableCell padding="checkbox">
+                      <IconButton
+                        size="small"
+                        aria-label={isExpanded ? 'Collapse labels' : 'Expand labels'}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRowClick(container.containerId);
+                        }}
+                      >
+                        {isExpanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell colSpan={4} sx={{ pb: 0, pt: 0, borderBottom: isExpanded ? undefined : 'none' }}>
+                      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                        <Box sx={{ py: 1.5, px: 1 }}>
+                          <Typography variant="subtitle2" gutterBottom>
+                            Labels
+                          </Typography>
+                          {sortedLabels.length === 0 ? (
+                            <Typography variant="body2" color="text.secondary">
+                              No labels
+                            </Typography>
+                          ) : (
+                            <Stack spacing={0.25}>
+                              {sortedLabels.map(([key, value]) => (
+                                <Stack key={key} direction="row" spacing={2} alignItems="baseline">
+                                  <Typography
+                                    variant="body2"
+                                    sx={{
+                                      fontFamily: 'monospace',
+                                      color: 'text.secondary',
+                                      minWidth: 240,
+                                      flexShrink: 0,
+                                    }}
+                                  >
+                                    {key}
+                                  </Typography>
+                                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                                    {value}
+                                  </Typography>
+                                </Stack>
+                              ))}
+                            </Stack>
+                          )}
+                        </Box>
+                      </Collapse>
+                    </TableCell>
+                  </TableRow>
+                </React.Fragment>
               );
             })}
           </TableBody>

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -30,6 +30,8 @@ import {
   Stack,
   Collapse,
   Box,
+  Button,
+  Skeleton,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -43,6 +45,7 @@ interface ContainersTableProps {
   isLoading: boolean;
   error: string | null;
   onCopyToClipboard: (text: string, label: string) => void;
+  onRetry?: () => void;
 }
 
 export function ContainersTable({
@@ -50,6 +53,7 @@ export function ContainersTable({
   isLoading,
   error,
   onCopyToClipboard,
+  onRetry,
 }: ContainersTableProps) {
   const [expandedContainer, setExpandedContainer] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<'name' | 'id'>('name');
@@ -112,24 +116,34 @@ export function ContainersTable({
 
   if (isLoading && containers.length === 0) {
     return (
-      <Typography variant="body1" color="text.secondary">
-        Loading containers...
-      </Typography>
+      <Stack spacing={1}>
+        <Skeleton variant="rectangular" height={40} />
+        <Skeleton variant="rectangular" height={40} />
+        <Skeleton variant="rectangular" height={40} />
+      </Stack>
     );
   }
 
   if (error) {
     return (
-      <Typography variant="body1" color="error">
-        {error}
-      </Typography>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Typography variant="body1" color="error">
+          {error}
+        </Typography>
+        {onRetry && (
+          <Button size="small" variant="outlined" color="error" onClick={onRetry}>
+            Retry
+          </Button>
+        )}
+      </Stack>
     );
   }
 
   if (containers.length === 0) {
     return (
       <Typography variant="body1" color="text.secondary">
-        No tracked containers found
+        No containers with the IMDS proxy label are running. Start a container with the label above
+        to see it here.
       </Typography>
     );
   }

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -26,7 +26,6 @@ import {
   IconButton,
   Tooltip,
   Typography,
-  TablePagination,
   Stack,
   Collapse,
   Box,
@@ -58,8 +57,6 @@ export function ContainersTable({
   const [expandedContainer, setExpandedContainer] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<'name' | 'id'>('name');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
 
   const handleSort = (column: 'name' | 'id') => {
     const isAsc = sortBy === column && sortOrder === 'asc';
@@ -68,42 +65,16 @@ export function ContainersTable({
   };
 
   const sortedContainers = useMemo(() => {
-    const sorted = [...containers].sort((a, b) => {
-      let aValue: string;
-      let bValue: string;
-
-      if (sortBy === 'name') {
-        aValue = cleanContainerName(a.name).toLowerCase();
-        bValue = cleanContainerName(b.name).toLowerCase();
-      } else {
-        aValue = a.containerId;
-        bValue = b.containerId;
-      }
-
-      if (sortOrder === 'asc') {
-        return aValue.localeCompare(bValue);
-      } else {
-        return bValue.localeCompare(aValue);
-      }
+    return [...containers].sort((a, b) => {
+      const aValue = sortBy === 'name'
+        ? cleanContainerName(a.name).toLowerCase()
+        : a.containerId;
+      const bValue = sortBy === 'name'
+        ? cleanContainerName(b.name).toLowerCase()
+        : b.containerId;
+      return sortOrder === 'asc' ? aValue.localeCompare(bValue) : bValue.localeCompare(aValue);
     });
-
-    return sorted;
   }, [containers, sortBy, sortOrder]);
-
-  const paginatedContainers = useMemo(() => {
-    const startIndex = page * rowsPerPage;
-    const endIndex = startIndex + rowsPerPage;
-    return sortedContainers.slice(startIndex, endIndex);
-  }, [sortedContainers, page, rowsPerPage]);
-
-  const handleChangePage = (event: unknown, newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  };
 
   const handleRowClick = (containerId: string) => {
     setExpandedContainer((prev) => (prev === containerId ? null : containerId));
@@ -149,10 +120,10 @@ export function ContainersTable({
   }
 
   return (
-    <>
-      <Typography variant="h6">Enabled for these containers</Typography>
-      <TableContainer component={Paper} variant="outlined">
-        <Table size="small">
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+      <Typography variant="subtitle1" sx={{ mb: 1 }}>Enabled for these containers</Typography>
+      <TableContainer component={Paper} variant="outlined" sx={{ flex: 1, overflow: 'auto' }}>
+        <Table size="small" stickyHeader>
           <TableHead>
             <TableRow>
               <TableCell>
@@ -178,7 +149,7 @@ export function ContainersTable({
             </TableRow>
           </TableHead>
           <TableBody>
-            {paginatedContainers.map((container) => {
+            {sortedContainers.map((container) => {
               const displayName = cleanContainerName(container.name);
               const isExpanded = expandedContainer === container.containerId;
               const sortedLabels = Object.entries(container.labels).sort(([a], [b]) =>
@@ -324,17 +295,9 @@ export function ContainersTable({
           </TableBody>
         </Table>
       </TableContainer>
-      {containers.length > 0 && (
-        <TablePagination
-          rowsPerPageOptions={[10, 25, 50, 100]}
-          component="div"
-          count={containers.length}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={handleChangePage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-      )}
-    </>
+      <Typography variant="body2" color="text.secondary" align="right" sx={{ mt: 0.5 }}>
+        Showing {containers.length} {containers.length === 1 ? 'item' : 'items'}
+      </Typography>
+    </Box>
   );
 }

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -133,41 +133,38 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
   };
 
   return (
-    <Stack spacing={2}>
-      <Stack spacing={1}>
-        <Typography variant="h6">Settings</Typography>
-      </Stack>
+    <Stack spacing={1}>
+      <Typography variant="subtitle1">Settings</Typography>
       {isLoadingSettings ? (
         <Skeleton variant="rectangular" height={40} />
       ) : (
-        <TextField
-          type="text"
-          label="URL of your IMDS server"
-          value={url}
-          onChange={(e) => {
-            setUrl(e.target.value);
-            setUrlError(false);
-          }}
-          variant="outlined"
-          size="small"
-          error={urlError}
-          helperText={
-            urlError
-              ? 'URL is required'
-              : 'Examples: http://localhost:8080, http://example.com:8080, https://api.example.com'
-          }
-          fullWidth
-          spellCheck={false}
-        />
+        <>
+          <TextField
+            type="text"
+            label="IMDS server URL"
+            placeholder="http://localhost:8080"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              setUrlError(false);
+            }}
+            variant="outlined"
+            size="small"
+            error={urlError}
+            helperText={urlError ? 'URL is required' : 'Examples: http://localhost:8080, https://api.example.com'}
+            fullWidth
+            spellCheck={false}
+          />
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={isSaving || url === savedUrl || isDebouncing}
+            sx={{ alignSelf: 'flex-start' }}
+          >
+            {isSaving ? 'Saving...' : url === savedUrl && savedUrl !== '' ? 'Saved' : 'Save Settings'}
+          </Button>
+        </>
       )}
-      <Button
-        variant="contained"
-        onClick={handleSave}
-        disabled={isSaving || url === savedUrl || isDebouncing}
-        sx={{ alignSelf: 'flex-start' }}
-      >
-        {isSaving ? 'Saving...' : url === savedUrl && savedUrl !== '' ? 'Saved' : 'Save Settings'}
-      </Button>
     </Stack>
   );
 }

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -13,20 +13,31 @@
 // limitations under the License.
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Stack, TextField, Typography, Skeleton } from '@mui/material';
+import { Stack, TextField, Typography, Skeleton, Alert } from '@mui/material';
 import Button from '@mui/material/Button';
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 import { DockerDesktopServiceClient } from '../services/dockerDesktopService';
 import { isSettingsResponse } from '../types';
-import { SAVE_DEBOUNCE_MS } from '../constants';
+import { SAVE_DEBOUNCE_MS, BACKEND_REQUEST_TIMEOUT_MS } from '../constants';
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Request timed out')), ms)
+    ),
+  ]);
+}
 
 interface SettingsFormProps {
   ddClient: ReturnType<typeof createDockerDesktopClient> | null;
   service: DockerDesktopServiceClient;
   showSnackbar: (message: string, severity: 'success' | 'error') => void;
+  proxyUnreachable?: boolean;
+  onProxyHelp?: () => void;
 }
 
-export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormProps) {
+export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable, onProxyHelp }: SettingsFormProps) {
   const [url, setUrl] = useState('');
   const [urlError, setUrlError] = useState(false);
   const [savedUrl, setSavedUrl] = useState('');
@@ -47,7 +58,7 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
     const loadSettings = async () => {
       setIsLoadingSettings(true);
       try {
-        const result = await service.getSettings();
+        const result = await withTimeout(service.getSettings(), BACKEND_REQUEST_TIMEOUT_MS);
         if (isSettingsResponse(result)) {
           const settings = result;
           const url = settings.url || '';
@@ -60,16 +71,11 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
           showSnackbar('Unexpected settings response format', 'error');
         }
       } catch (error) {
-        if (isMountedRef.current) {
-          showSnackbar('Failed to load settings from backend', 'error');
-        }
-        // Fallback to localStorage if backend is not available
+        // Silently fall back to localStorage if the backend is unavailable.
         const savedUrl = localStorage.getItem('url') || '';
-
         if (isMountedRef.current) {
           setUrl(savedUrl);
           setSavedUrl(savedUrl);
-          showSnackbar('Backend unavailable, using local settings', 'error');
         }
       } finally {
         if (isMountedRef.current) {
@@ -105,7 +111,10 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
     try {
       const settings = { url };
 
-      await ddClient.extension.vm?.service?.post('/settings', settings);
+      await withTimeout(
+        ddClient.extension.vm?.service?.post('/settings', settings) ?? Promise.resolve(),
+        BACKEND_REQUEST_TIMEOUT_MS,
+      );
 
       // Save settings locally after successful backend save
       localStorage.setItem('url', url);
@@ -135,6 +144,20 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
   return (
     <Stack spacing={1}>
       <Typography variant="subtitle1">Settings</Typography>
+      {proxyUnreachable && (
+        <Alert
+          severity="warning"
+          action={
+            onProxyHelp && (
+              <Button color="inherit" size="small" onClick={onProxyHelp}>
+                Get help
+              </Button>
+            )
+          }
+        >
+          Extension backend not responding. Your last saved settings are shown below, but changes cannot be saved.
+        </Alert>
+      )}
       {isLoadingSettings ? (
         <Skeleton variant="rectangular" height={40} />
       ) : (
@@ -158,7 +181,7 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
           <Button
             variant="contained"
             onClick={handleSave}
-            disabled={isSaving || url === savedUrl || isDebouncing}
+            disabled={isSaving || url === savedUrl || isDebouncing || proxyUnreachable}
             sx={{ alignSelf: 'flex-start' }}
           >
             {isSaving ? 'Saving...' : url === savedUrl && savedUrl !== '' ? 'Saved' : 'Save Settings'}

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -166,7 +166,7 @@ export function SettingsForm({ ddClient, service, showSnackbar }: SettingsFormPr
         disabled={isSaving || url === savedUrl || isDebouncing}
         sx={{ alignSelf: 'flex-start' }}
       >
-        {isSaving ? 'Saving...' : 'Save Settings'}
+        {isSaving ? 'Saving...' : url === savedUrl && savedUrl !== '' ? 'Saved' : 'Save Settings'}
       </Button>
     </Stack>
   );

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -41,3 +41,9 @@ export const GITHUB_REPO_URL = 'https://github.com/imdsutil/barnacle-imds-proxy'
  * Container label that enables IMDS proxying
  */
 export const IMDS_PROXY_ENABLED_LABEL = 'imds-proxy.enabled=true';
+
+/**
+ * Timeout for backend API calls (in milliseconds). Calls that hang beyond this
+ * are treated as failures so the UI does not wait indefinitely.
+ */
+export const BACKEND_REQUEST_TIMEOUT_MS = 5000;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -31,7 +31,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     */}
     <DockerMuiV6ThemeProvider>
       <CssBaseline />
-      <GlobalStyles styles={{ html: { scrollbarGutter: 'stable' }, body: { margin: 0, paddingLeft: '16px' } }} />
+      <GlobalStyles styles={{ html: { scrollbarGutter: 'stable', overflow: 'hidden' }, body: { margin: 0, paddingLeft: '16px', overflow: 'hidden' } }} />
       <App />
     </DockerMuiV6ThemeProvider>
   </React.StrictMode>

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -17,6 +17,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import CssBaseline from "@mui/material/CssBaseline";
+import GlobalStyles from "@mui/material/GlobalStyles";
 import { DockerMuiV6ThemeProvider } from "@docker/docker-mui-theme";
 
 import { App } from './App';
@@ -30,6 +31,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     */}
     <DockerMuiV6ThemeProvider>
       <CssBaseline />
+      <GlobalStyles styles={{ html: { scrollbarGutter: 'stable' } }} />
       <App />
     </DockerMuiV6ThemeProvider>
   </React.StrictMode>

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -31,7 +31,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     */}
     <DockerMuiV6ThemeProvider>
       <CssBaseline />
-      <GlobalStyles styles={{ html: { scrollbarGutter: 'stable' } }} />
+      <GlobalStyles styles={{ html: { scrollbarGutter: 'stable' }, body: { margin: 0, paddingLeft: '16px' } }} />
       <App />
     </DockerMuiV6ThemeProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary

A full UX pass on the Docker Desktop extension UI, addressing layout, usability, error states, and information architecture.

### Layout & structure
- Full-height scrollable container table with sticky header; no pagination
- Tabs (Containers / Settings) matching Docker Desktop's native section style
- Left margin and padding aligned with Docker Desktop native sections
- Scrollbar scoped to the table only; no main viewport scrollbar

### Container table
- Expandable rows showing all container labels
- Copy affordance (hover-reveal copy buttons) for container name and ID
- Sort by name or container ID
- Footer row always visible: left shows backend status indicator, right shows item count

### Backend unreachable state
- 5s request timeout on all backend API calls; skeleton clears on definitive outcome rather than a fixed safety timeout
- Network events (`connect`/`disconnect`) handled in the backend event loop to keep stored container networks fresh
- When the backend is unreachable, the container table stays visible with last known state; a persistent footer indicator ("Extension backend not responding — list may be outdated") opens a help dialog
- Help dialog accurately distinguishes between the controller (unreachable) and the IMDS proxy (separate container, may still be working)
- Settings tab shows a warning Alert with a "Get help" action when the backend is unreachable; Save button disabled in that state
- `withTimeout` applied to the settings save POST to prevent the button hanging indefinitely

### Settings tab
- Save button state: "Save Settings" → "Saving…" → "Saved"
- Settings load falls back silently to localStorage when the backend is unavailable
- Save debounce to prevent rapid re-submission