### PR TITLE
feat!: drive IMDS networks from user-configured IP list

### DIFF
--- a/backend/handlers_echo_test.go
+++ b/backend/handlers_echo_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -25,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/labstack/echo/v4"
 )
 
@@ -33,6 +35,10 @@ func withNoOpNotify(t *testing.T) {
 	old := notifyProxyConfigUpdateFn
 	notifyProxyConfigUpdateFn = func() {}
 	t.Cleanup(func() { notifyProxyConfigUpdateFn = old })
+
+	oldReconcile := reconcileNetworksFn
+	reconcileNetworksFn = func(_ context.Context, _ DockerClient, _ []NetworkConfig) error { return nil }
+	t.Cleanup(func() { reconcileNetworksFn = oldReconcile })
 }
 
 func withTempSettingsPath(t *testing.T) {
@@ -158,6 +164,202 @@ func TestSaveSettingsInvalidJSON(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want status 400, got %d", rec.Code)
+	}
+}
+
+func TestSaveSettingsWithCustomIPs(t *testing.T) {
+	withTempSettingsPath(t)
+	withSettings(t, Settings{})
+	withNoOpNotify(t)
+
+	e := echo.New()
+	body := strings.NewReader(`{"url":"http://example.com","customIPs":["169.254.169.254","fd00:ec2::254"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/settings", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := saveSettings(c); err != nil {
+		t.Fatalf("saveSettings() returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+
+	settingsMutex.RLock()
+	nets := settings.NetworkConfig
+	settingsMutex.RUnlock()
+
+	if len(nets) != 1 {
+		t.Fatalf("want 1 network config, got %d", len(nets))
+	}
+	if nets[0].ProxyIPv4 != "169.254.169.254" {
+		t.Errorf("want ProxyIPv4 169.254.169.254, got %q", nets[0].ProxyIPv4)
+	}
+	if nets[0].ProxyIPv6 != "fd00:ec2::254" {
+		t.Errorf("want ProxyIPv6 fd00:ec2::254, got %q", nets[0].ProxyIPv6)
+	}
+}
+
+func TestComputeNetworkConfigEmpty(t *testing.T) {
+	if nets := computeNetworkConfig([]string{}); len(nets) != 0 {
+		t.Fatalf("want 0 networks, got %d", len(nets))
+	}
+}
+
+func TestComputeNetworkConfigIPv4Only(t *testing.T) {
+	nets := computeNetworkConfig([]string{"169.254.169.254"})
+	if len(nets) != 1 {
+		t.Fatalf("want 1 network, got %d", len(nets))
+	}
+	if nets[0].ProxyIPv4 != "169.254.169.254" {
+		t.Errorf("want ProxyIPv4 169.254.169.254, got %q", nets[0].ProxyIPv4)
+	}
+	if nets[0].IPv6Subnet != "" {
+		t.Errorf("want no IPv6 subnet, got %q", nets[0].IPv6Subnet)
+	}
+}
+
+func TestComputeNetworkConfigIPv6Only(t *testing.T) {
+	nets := computeNetworkConfig([]string{"fd00:ec2::254"})
+	if len(nets) != 1 {
+		t.Fatalf("want 1 network, got %d", len(nets))
+	}
+	if nets[0].ProxyIPv6 != "fd00:ec2::254" {
+		t.Errorf("want ProxyIPv6 fd00:ec2::254, got %q", nets[0].ProxyIPv6)
+	}
+	if nets[0].IPv4Subnet != "" {
+		t.Errorf("want no IPv4 subnet, got %q", nets[0].IPv4Subnet)
+	}
+}
+
+func TestComputeNetworkConfigInvalidIPSkipped(t *testing.T) {
+	nets := computeNetworkConfig([]string{"not-an-ip", "169.254.169.254"})
+	if len(nets) != 1 {
+		t.Fatalf("want 1 network (invalid IP skipped), got %d", len(nets))
+	}
+}
+
+func TestComputeNetworkConfigDeduplicatesSubnet(t *testing.T) {
+	nets := computeNetworkConfig([]string{"169.254.169.254", "169.254.169.1"})
+	if len(nets) != 1 {
+		t.Fatalf("want 1 network for same /24, got %d", len(nets))
+	}
+}
+
+func TestReconcileNetworksCreatesNew(t *testing.T) {
+	managedNetworksMutex.Lock()
+	managedNetworks = nil
+	managedNetworksMutex.Unlock()
+	t.Cleanup(func() {
+		managedNetworksMutex.Lock()
+		managedNetworks = nil
+		managedNetworksMutex.Unlock()
+	})
+
+	cli := &fakeDockerClient{networkList: []network.Summary{}}
+	desired := []NetworkConfig{{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254"}}
+
+	if err := reconcileNetworks(context.Background(), cli, desired); err != nil {
+		t.Fatalf("reconcileNetworks() error: %v", err)
+	}
+	if len(cli.networkCreateCalls) != 1 || cli.networkCreateCalls[0] != ".imds-0" {
+		t.Errorf("want networkCreate .imds-0, got %v", cli.networkCreateCalls)
+	}
+}
+
+func TestReconcileNetworksRemovesUnneeded(t *testing.T) {
+	managedNetworksMutex.Lock()
+	managedNetworks = nil
+	managedNetworksMutex.Unlock()
+	t.Cleanup(func() {
+		managedNetworksMutex.Lock()
+		managedNetworks = nil
+		managedNetworksMutex.Unlock()
+	})
+
+	cli := &fakeDockerClient{
+		networkList: []network.Summary{
+			{ID: "net-abc", Name: ".imds-0", Labels: map[string]string{imdsManagedLabel: "true"}},
+		},
+	}
+
+	if err := reconcileNetworks(context.Background(), cli, []NetworkConfig{}); err != nil {
+		t.Fatalf("reconcileNetworks() error: %v", err)
+	}
+	if len(cli.networkRemoveCalls) != 1 || cli.networkRemoveCalls[0] != "net-abc" {
+		t.Errorf("want networkRemove net-abc, got %v", cli.networkRemoveCalls)
+	}
+}
+
+func TestReconcileNetworksRemovesOnSubnetChange(t *testing.T) {
+	managedNetworksMutex.Lock()
+	managedNetworks = nil
+	managedNetworksMutex.Unlock()
+	t.Cleanup(func() {
+		managedNetworksMutex.Lock()
+		managedNetworks = nil
+		managedNetworksMutex.Unlock()
+	})
+
+	cli := &fakeDockerClient{
+		networkList: []network.Summary{
+			{
+				ID:     "net-old",
+				Name:   ".imds-0",
+				Labels: map[string]string{imdsManagedLabel: "true"},
+				IPAM: network.IPAM{
+					Config: []network.IPAMConfig{{Subnet: "169.254.169.0/24"}},
+				},
+			},
+		},
+	}
+	desired := []NetworkConfig{
+		{Name: ".imds-0", IPv4Subnet: "10.0.0.0/24", ProxyIPv4: "10.0.0.1"},
+	}
+
+	if err := reconcileNetworks(context.Background(), cli, desired); err != nil {
+		t.Fatalf("reconcileNetworks() error: %v", err)
+	}
+	if len(cli.networkRemoveCalls) != 1 || cli.networkRemoveCalls[0] != "net-old" {
+		t.Errorf("want networkRemove net-old, got %v", cli.networkRemoveCalls)
+	}
+	if len(cli.networkCreateCalls) != 1 || cli.networkCreateCalls[0] != ".imds-0" {
+		t.Errorf("want networkCreate .imds-0, got %v", cli.networkCreateCalls)
+	}
+}
+
+func TestReconcileNetworksListError(t *testing.T) {
+	cli := &fakeDockerClient{networkListErr: errors.New("docker unavailable")}
+	if err := reconcileNetworks(context.Background(), cli, nil); err == nil {
+		t.Fatal("want error when NetworkList fails, got nil")
+	}
+}
+
+func TestDisconnectAllFromNetwork(t *testing.T) {
+	cli := &fakeDockerClient{
+		containerList: []container.Summary{
+			{
+				ID: "ctr1",
+				NetworkSettings: &container.NetworkSettingsSummary{
+					Networks: map[string]*network.EndpointSettings{".imds-0": {}},
+				},
+			},
+		},
+	}
+
+	if err := disconnectAllFromNetwork(context.Background(), cli, ".imds-0"); err != nil {
+		t.Fatalf("disconnectAllFromNetwork() error: %v", err)
+	}
+	if len(cli.networkDisconnectCalls) != 1 || cli.networkDisconnectCalls[0] != ".imds-0:ctr1" {
+		t.Errorf("want disconnect .imds-0:ctr1, got %v", cli.networkDisconnectCalls)
+	}
+}
+
+func TestDisconnectAllFromNetworkListError(t *testing.T) {
+	cli := &fakeDockerClient{containerListErr: errors.New("list failed")}
+	if err := disconnectAllFromNetwork(context.Background(), cli, ".imds-0"); err == nil {
+		t.Fatal("want error when ContainerList fails, got nil")
 	}
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -63,7 +64,90 @@ const (
 var proxyNotificationSocketPath = "/var/run/imds-proxy/notifications.sock"
 
 type Settings struct {
-	URL string `json:"url"`
+	URL              string          `json:"url"`
+	CustomIPs        []string        `json:"customIPs,omitempty"`
+	NetworkConfig    []NetworkConfig `json:"networkConfig,omitempty"`
+}
+
+// NetworkConfig describes a Docker bridge network the backend should manage.
+// Computed from CustomIPs; not user-editable.
+type NetworkConfig struct {
+	Name       string `json:"name"`
+	IPv4Subnet string `json:"ipv4Subnet,omitempty"`
+	IPv6Subnet string `json:"ipv6Subnet,omitempty"`
+	ProxyIPv4  string `json:"proxyIPv4,omitempty"`
+	ProxyIPv6  string `json:"proxyIPv6,omitempty"`
+	Providers  string `json:"providers"`
+}
+
+// computeNetworkConfig derives the Docker network configuration needed to
+// handle the given IMDS addresses. Each bridge network supports at most one
+// IPv4 subnet and one IPv6 subnet, so addresses are grouped by subnet.
+func computeNetworkConfig(ips []string) []NetworkConfig {
+	type subnetInfo struct {
+		subnet  string
+		proxyIP string
+		isIPv6  bool
+	}
+	seen := make(map[string]subnetInfo)
+
+	for _, ip := range ips {
+		ip = strings.TrimSpace(ip)
+		if ip == "" {
+			continue
+		}
+		parsed := net.ParseIP(ip)
+		if parsed == nil {
+			continue
+		}
+		if parsed.To4() != nil {
+			v4 := parsed.To4()
+			subnet := net.IPNet{IP: net.IPv4(v4[0], v4[1], v4[2], 0), Mask: net.CIDRMask(24, 32)}
+			subnetStr := subnet.String()
+			if _, exists := seen[subnetStr]; !exists {
+				seen[subnetStr] = subnetInfo{subnet: subnetStr, proxyIP: ip, isIPv6: false}
+			}
+		} else {
+			v6 := parsed.To16()
+			prefix := make(net.IP, 16)
+			copy(prefix, v6[:8])
+			subnet := net.IPNet{IP: prefix, Mask: net.CIDRMask(64, 128)}
+			subnetStr := subnet.String()
+			if _, exists := seen[subnetStr]; !exists {
+				seen[subnetStr] = subnetInfo{subnet: subnetStr, proxyIP: ip, isIPv6: true}
+			}
+		}
+	}
+
+	var v4Subnets, v6Subnets []string
+	for key, info := range seen {
+		if info.isIPv6 {
+			v6Subnets = append(v6Subnets, key)
+		} else {
+			v4Subnets = append(v4Subnets, key)
+		}
+	}
+	sort.Strings(v4Subnets)
+	sort.Strings(v6Subnets)
+
+	var configs []NetworkConfig
+	netIndex := 0
+	for i := 0; i < len(v4Subnets) || i < len(v6Subnets); i++ {
+		cfg := NetworkConfig{Name: fmt.Sprintf(".imds-%d", netIndex)}
+		if i < len(v4Subnets) {
+			v4 := seen[v4Subnets[i]]
+			cfg.IPv4Subnet = v4.subnet
+			cfg.ProxyIPv4 = v4.proxyIP
+		}
+		if i < len(v6Subnets) {
+			v6 := seen[v6Subnets[i]]
+			cfg.IPv6Subnet = v6.subnet
+			cfg.ProxyIPv6 = v6.proxyIP
+		}
+		configs = append(configs, cfg)
+		netIndex++
+	}
+	return configs
 }
 
 type ProxyLookupRequest struct {
@@ -135,6 +219,9 @@ var findContainerByIPFn = findContainerByIP
 // to avoid spawning background goroutines that race with test cleanup.
 var notifyProxyConfigUpdateFn = notifyProxyConfigUpdate
 
+// reconcileNetworksFn is a variable so tests can replace it with a no-op.
+var reconcileNetworksFn = reconcileNetworks
+
 func queryProxyContainerState(ctx context.Context, cli DockerClient) ProxyContainerState {
 	inspect, err := cli.ContainerInspect(ctx, proxyContainerName)
 	if err != nil {
@@ -168,7 +255,10 @@ type DockerClient interface {
 	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error)
 	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
+	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
 	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
+	NetworkRemove(ctx context.Context, networkID string) error
 	ContainerPause(ctx context.Context, containerID string) error
 	ContainerUnpause(ctx context.Context, containerID string) error
 	Close() error
@@ -222,6 +312,20 @@ func main() {
 	if err := loadSettings(); err != nil {
 		logger.Warnf("Failed to load settings from disk: %v", err)
 	}
+
+	// Reconcile networks on startup so Docker state matches saved settings.
+	// Runs in background so startup is not blocked; also cleans up stale
+	// compose-managed networks left over from previous installs.
+	go func() {
+		settingsMutex.RLock()
+		netConfig := settings.NetworkConfig
+		settingsMutex.RUnlock()
+		rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := reconcileNetworksFn(rctx, dockerClient, netConfig); err != nil {
+			logger.Warnf("Startup network reconciliation failed: %v", err)
+		}
+	}()
 
 	// Start monitoring Docker events
 	go monitorDockerEvents()
@@ -362,6 +466,8 @@ func saveSettings(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, map[string]string{"error": "url is required"})
 	}
 
+	newSettings.NetworkConfig = computeNetworkConfig(newSettings.CustomIPs)
+
 	settingsMutex.Lock()
 	settings = newSettings
 	settingsMutex.Unlock()
@@ -372,10 +478,23 @@ func saveSettings(ctx echo.Context) error {
 		return ctx.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to save settings"})
 	}
 
+	// Reconcile Docker networks to match the new config.
+	// Capture the function variable to avoid races with test cleanup.
+	reconcileFn := reconcileNetworksFn
+	dc := dockerClient // capture to avoid race with test cleanup
+	go func() {
+		rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := reconcileFn(rctx, dc, newSettings.NetworkConfig); err != nil {
+			logger.Errorf("Failed to reconcile networks after settings save: %v", err)
+		}
+	}()
+
 	// Notify proxy of config update
 	go notifyProxyConfigUpdateFn()
 
-	logger.Infof("Settings saved: url=%s", newSettings.URL)
+	logger.Infof("Settings saved: url=%s customIPs=%v networks=%d",
+		newSettings.URL, newSettings.CustomIPs, len(newSettings.NetworkConfig))
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "Settings saved successfully"})
 }
 
@@ -543,9 +662,23 @@ func monitorDockerEvents() {
 
 	logger.Infof("Started monitoring Docker container events")
 
-	// Discover managed IMDS networks
-	if err := discoverManagedNetworks(ctx, dockerClient); err != nil {
-		logger.Errorf("Failed to discover managed networks: %v", err)
+	// If we have saved network config, reconcile networks to match.
+	// Otherwise just discover what's already there (compose defaults).
+	settingsMutex.RLock()
+	savedNetConfig := settings.NetworkConfig
+	settingsMutex.RUnlock()
+
+	if len(savedNetConfig) > 0 {
+		rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		if err := reconcileNetworks(rctx, dockerClient, savedNetConfig); err != nil {
+			logger.Errorf("Failed to reconcile networks on startup: %v", err)
+		}
+		cancel()
+	} else {
+		// No saved config -- discover existing networks (compose defaults)
+		if err := discoverManagedNetworks(ctx, dockerClient); err != nil {
+			logger.Errorf("Failed to discover managed networks: %v", err)
+		}
 	}
 
 	// Scan existing containers
@@ -849,6 +982,171 @@ func discoverManagedNetworks(ctx context.Context, cli DockerClient) error {
 	managedNetworksMutex.Unlock()
 
 	logger.Infof("Discovered %d managed IMDS network(s)", len(discovered))
+	return nil
+}
+
+// reconcileNetworks creates, removes, and reconnects Docker networks so the
+// actual state matches the desired NetworkConfig. It also reconnects the proxy
+// container and all tracked containers to the new networks.
+func reconcileNetworks(ctx context.Context, cli DockerClient, desired []NetworkConfig) error {
+	// 1. List existing managed networks
+	existing, err := cli.NetworkList(ctx, network.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("label", imdsManagedLabel+"=true")),
+	})
+	if err != nil {
+		return fmt.Errorf("listing managed networks: %w", err)
+	}
+
+	existingByName := make(map[string]network.Summary, len(existing))
+	for _, n := range existing {
+		existingByName[n.Name] = n
+	}
+
+	desiredByName := make(map[string]NetworkConfig, len(desired))
+	for _, d := range desired {
+		desiredByName[d.Name] = d
+	}
+
+	// 2. Remove networks that are no longer needed or whose subnets changed.
+	// Docker bridge networks can't be modified in place, so a subnet change
+	// requires removing and recreating the network.
+	for name, n := range existingByName {
+		d, want := desiredByName[name]
+		keep := want && networkSubnetsMatch(n, d)
+		if keep {
+			continue
+		}
+		reason := "unneeded"
+		if want {
+			reason = "subnet changed"
+		}
+		logger.Infof("Removing network %s (%s)", name, reason)
+		if err := disconnectAllFromNetwork(ctx, cli, name); err != nil {
+			logger.Warnf("Failed to disconnect containers from %s: %v", name, err)
+		}
+		if err := cli.NetworkRemove(ctx, n.ID); err != nil {
+			logger.Errorf("Failed to remove network %s: %v", name, err)
+			continue
+		}
+		delete(existingByName, name)
+	}
+
+	// 3. Create missing networks
+	for _, d := range desired {
+		if _, exists := existingByName[d.Name]; exists {
+			continue
+		}
+		logger.Infof("Creating network %s (v4=%s v6=%s)", d.Name, d.IPv4Subnet, d.IPv6Subnet)
+		ipamConfigs := []network.IPAMConfig{}
+		if d.IPv4Subnet != "" {
+			ipamConfigs = append(ipamConfigs, network.IPAMConfig{Subnet: d.IPv4Subnet})
+		}
+		if d.IPv6Subnet != "" {
+			ipamConfigs = append(ipamConfigs, network.IPAMConfig{Subnet: d.IPv6Subnet})
+		}
+
+		enableIPv6 := d.IPv6Subnet != ""
+		opts := network.CreateOptions{
+			Driver:     "bridge",
+			EnableIPv6: &enableIPv6,
+			IPAM: &network.IPAM{
+				Config: ipamConfigs,
+			},
+			Labels: map[string]string{
+				imdsManagedLabel:   "true",
+				imdsProvidersLabel: d.Providers,
+			},
+		}
+		if _, err := cli.NetworkCreate(ctx, d.Name, opts); err != nil {
+			logger.Errorf("Failed to create network %s: %v", d.Name, err)
+			continue
+		}
+	}
+
+	// 4. Connect proxy container to new networks with correct IPs
+	for _, d := range desired {
+		endpointConfig := &network.EndpointSettings{}
+		if d.ProxyIPv4 != "" || d.ProxyIPv6 != "" {
+			ipamConfig := &network.EndpointIPAMConfig{}
+			if d.ProxyIPv4 != "" {
+				ipamConfig.IPv4Address = d.ProxyIPv4
+			}
+			if d.ProxyIPv6 != "" {
+				ipamConfig.IPv6Address = d.ProxyIPv6
+			}
+			endpointConfig.IPAMConfig = ipamConfig
+		}
+		if err := cli.NetworkConnect(ctx, d.Name, proxyContainerName, endpointConfig); err != nil {
+			// May already be connected -- log but don't fail
+			logger.Debugf("Connect proxy to %s: %v", d.Name, err)
+		}
+	}
+
+	// 5. Reconnect tracked containers to the new networks
+	trackedContainersMutex.RLock()
+	containerIDs := make([]string, 0, len(trackedContainers))
+	for id := range trackedContainers {
+		containerIDs = append(containerIDs, id)
+	}
+	trackedContainersMutex.RUnlock()
+
+	for _, cid := range containerIDs {
+		for _, d := range desired {
+			if err := cli.NetworkConnect(ctx, d.Name, cid, nil); err != nil {
+				logger.Debugf("Connect container %s to %s: %v", shortID(cid), d.Name, err)
+			}
+		}
+	}
+
+	// 6. Refresh the in-memory managed networks cache
+	if err := discoverManagedNetworks(ctx, cli); err != nil {
+		logger.Warnf("Failed to refresh managed networks after reconciliation: %v", err)
+	}
+
+	logger.Infof("Network reconciliation complete: %d network(s) configured", len(desired))
+	return nil
+}
+
+// networkSubnetsMatch reports whether an existing managed network's IPAM
+// subnets exactly match the desired NetworkConfig (set-equal on subnet CIDR).
+func networkSubnetsMatch(existing network.Summary, desired NetworkConfig) bool {
+	want := map[string]bool{}
+	if desired.IPv4Subnet != "" {
+		want[desired.IPv4Subnet] = true
+	}
+	if desired.IPv6Subnet != "" {
+		want[desired.IPv6Subnet] = true
+	}
+	have := map[string]bool{}
+	for _, c := range existing.IPAM.Config {
+		if c.Subnet != "" {
+			have[c.Subnet] = true
+		}
+	}
+	if len(want) != len(have) {
+		return false
+	}
+	for s := range want {
+		if !have[s] {
+			return false
+		}
+	}
+	return true
+}
+
+// disconnectAllFromNetwork disconnects all containers from a network.
+// networkName is the user-facing network name (matches keys in
+// c.NetworkSettings.Networks); NetworkDisconnect accepts either name or ID.
+func disconnectAllFromNetwork(ctx context.Context, cli DockerClient, networkName string) error {
+	containers, err := cli.ContainerList(ctx, container.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, c := range containers {
+		if _, attached := c.NetworkSettings.Networks[networkName]; attached {
+			_ = cli.NetworkDisconnect(ctx, networkName, c.ID, true)
+		}
+	}
 	return nil
 }
 

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -30,17 +30,22 @@ import (
 )
 
 type fakeDockerClient struct {
-	inspectCalls        int
-	inspectSequence     []container.InspectResponse
-	inspectErr          error
-	networkConnectCalls []string
-	pauseCalls          int
-	unpauseCalls        int
-	closeCalls          int
-	containerList       []container.Summary
-	containerListErr    error
-	networkList         []network.Summary
-	networkListErr      error
+	inspectCalls            int
+	inspectSequence         []container.InspectResponse
+	inspectErr              error
+	networkConnectCalls     []string
+	networkCreateCalls      []string
+	networkDisconnectCalls  []string
+	networkRemoveCalls      []string
+	pauseCalls              int
+	unpauseCalls            int
+	closeCalls              int
+	containerList           []container.Summary
+	containerListErr        error
+	networkList             []network.Summary
+	networkListErr          error
+	networkCreateErr        error
+	networkRemoveErr        error
 }
 
 func (f *fakeDockerClient) ContainerInspect(_ context.Context, _ string) (container.InspectResponse, error) {
@@ -68,6 +73,27 @@ func (f *fakeDockerClient) Events(_ context.Context, _ events.ListOptions) (<-ch
 
 func (f *fakeDockerClient) NetworkConnect(_ context.Context, networkID, _ string, _ *network.EndpointSettings) error {
 	f.networkConnectCalls = append(f.networkConnectCalls, networkID)
+	return nil
+}
+
+func (f *fakeDockerClient) NetworkCreate(_ context.Context, name string, _ network.CreateOptions) (network.CreateResponse, error) {
+	f.networkCreateCalls = append(f.networkCreateCalls, name)
+	if f.networkCreateErr != nil {
+		return network.CreateResponse{}, f.networkCreateErr
+	}
+	return network.CreateResponse{ID: "net-" + name}, nil
+}
+
+func (f *fakeDockerClient) NetworkDisconnect(_ context.Context, networkID, containerID string, _ bool) error {
+	f.networkDisconnectCalls = append(f.networkDisconnectCalls, networkID+":"+containerID)
+	return nil
+}
+
+func (f *fakeDockerClient) NetworkRemove(_ context.Context, networkID string) error {
+	f.networkRemoveCalls = append(f.networkRemoveCalls, networkID)
+	if f.networkRemoveErr != nil {
+		return f.networkRemoveErr
+	}
 	return nil
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,14 +21,6 @@ services:
     image: barnacle-imds-proxy-proxy:latest
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    networks:
-      # IPv4 + EC2 IPv6 IMDS addresses (AWS, GCP, OpenStack v4)
-      imds_0:
-        ipv4_address: 169.254.169.254
-        ipv6_address: "fd00:ec2::254"
-      # OpenStack IPv6 IMDS address
-      imds_1:
-        ipv6_address: "fd00:a9fe:a9fe::254"
     volumes:
       # So we can communicate with the controller
       - imds-proxy-sockets:/var/run/imds-proxy:rw
@@ -38,29 +30,3 @@ services:
 volumes:
   imds-proxy-config:
   imds-proxy-sockets:
-
-networks:
-  # Network 0: IPv4 IMDS (169.254.169.254) + EC2 IPv6 (fd00:ec2::254)
-  imds_0:
-    name: ".imds-0"
-    driver: bridge
-    enable_ipv6: true
-    labels:
-      imds-proxy.managed: "true"
-      imds-proxy.providers: "AWS=v4,v6;GCP=v4,v6;OpenStack=v4"
-    ipam:
-      config:
-        - subnet: 169.254.169.0/24
-        - subnet: "fd00:ec2::/64"
-
-  # Network 1: OpenStack IPv6 IMDS address (fd00:a9fe:a9fe::254)
-  imds_1:
-    name: ".imds-1"
-    driver: bridge
-    enable_ipv6: true
-    labels:
-      imds-proxy.managed: "true"
-      imds-proxy.providers: "OpenStack=v6"
-    ipam:
-      config:
-        - subnet: "fd00:a9fe:a9fe::/64"

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -28,13 +28,13 @@ IMDS_SERVER_PORT="${IMDS_SERVER_PORT:-3333}"
 TEST_SERVER_PID=""
 CONTROLLER_SOCKET="/run/guest-services/backend.sock"
 
-# Update the extension backend URL via the controller's settings API
-set_backend_url() {
+# Update the extension settings via the controller's settings API
+set_settings() {
     local url="$1"
     docker exec imds-proxy-controller \
         curl -sf --unix-socket "$CONTROLLER_SOCKET" \
         -X POST -H 'Content-Type: application/json' \
-        -d "{\"url\":\"$url\"}" \
+        -d "{\"url\":\"$url\",\"customIPs\":[\"169.254.169.254\",\"fd00:ec2::254\"]}" \
         http://localhost/settings >/dev/null
 }
 
@@ -59,9 +59,9 @@ setup_file() {
             return 1
         fi
 
-        set_backend_url "http://localhost:$TEST_SERVER_PORT"
+        set_settings "http://localhost:$TEST_SERVER_PORT"
     else
-        set_backend_url "http://localhost:$IMDS_SERVER_PORT"
+        set_settings "http://localhost:$IMDS_SERVER_PORT"
     fi
 
     # Start a labeled container
@@ -93,14 +93,9 @@ teardown_file() {
     docker network ls --format '{{.Name}}' | grep -q '\.imds-0'
 }
 
-@test ".imds-1 network exists" {
-    docker network ls --format '{{.Name}}' | grep -q '\.imds-1'
-}
-
-@test "container is attached to IMDS networks" {
+@test "container is attached to .imds-0" {
     networks=$(docker inspect "$CONTAINER_NAME" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}')
     echo "$networks" | grep -q '\.imds-0'
-    echo "$networks" | grep -q '\.imds-1'
 }
 
 # --- reachability tests (use /status — present on both backends) ---
@@ -113,9 +108,6 @@ teardown_file() {
     docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 "http://[fd00:ec2::254]/status"
 }
 
-@test "IPv6 fd00:a9fe:a9fe::254 is reachable" {
-    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 "http://[fd00:a9fe:a9fe::254]/status"
-}
 
 # --- proxy header tests (test-server only) ---
 

--- a/ui/src/__tests__/settingsForm.test.tsx
+++ b/ui/src/__tests__/settingsForm.test.tsx
@@ -184,7 +184,10 @@ describe('SettingsForm', () => {
       await Promise.resolve(); // Flush microtasks
     });
 
-    expect(client.extension.vm.service.post).toHaveBeenCalledWith('/settings', { url: NEW_URL });
+    expect(client.extension.vm.service.post).toHaveBeenCalledWith('/settings', {
+      url: NEW_URL,
+      customIPs: expect.any(Array),
+    });
     expect(localStorage.getItem('url')).toBe(NEW_URL);
     expect(showSnackbar).toHaveBeenCalledWith('Settings saved', 'success');
     expect((button as HTMLButtonElement).disabled).toBe(true);
@@ -214,7 +217,7 @@ describe('SettingsForm', () => {
 
     // Wait for settings to load
     await waitFor(() => {
-      expect(screen.getByRole('textbox')).toBeDefined();
+      expect(screen.getByLabelText(/IMDS server URL/i)).toBeDefined();
     });
   });
 
@@ -228,9 +231,9 @@ describe('SettingsForm', () => {
 
     render(<SettingsForm ddClient={client as any} service={service} showSnackbar={showSnackbar} />);
 
-    await waitFor(() => expect(screen.getByRole('textbox')).toBeDefined());
+    await waitFor(() => expect(screen.getByLabelText(/IMDS server URL/i)).toBeDefined());
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByLabelText(/IMDS server URL/i);
     fireEvent.change(input, { target: { value: NEW_URL_VALUE } });
 
     const button = screen.getByRole('button', { name: /save settings/i });
@@ -251,18 +254,60 @@ describe('SettingsForm', () => {
     render(<SettingsForm ddClient={null} service={service} showSnackbar={showSnackbar} />);
 
     // Component renders, but should not call service methods without client
-    expect(screen.getByRole('textbox')).toBeDefined();
+    expect(screen.getByLabelText(/IMDS server URL/i)).toBeDefined();
     expect(service.getSettings).not.toHaveBeenCalled();
 
     // Attempting to save should show error
     const button = screen.getByRole('button', { name: /save settings/i });
-    const input = screen.getByRole('textbox');
+    const input = screen.getByLabelText(/IMDS server URL/i);
     fireEvent.change(input, { target: { value: TEST_URL } });
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(showSnackbar).toHaveBeenCalledWith('Docker Desktop client unavailable', 'error');
     });
+  });
+
+  it('adds a valid IPv4 address to the list', async () => {
+    const service = createMockService({
+      getSettings: vi.fn().mockResolvedValue({ url: SETTINGS_URL }),
+    });
+    render(<SettingsForm ddClient={createMockDockerDesktopClient() as any} service={service} showSnackbar={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByLabelText(/IP address/i)).toBeDefined());
+
+    fireEvent.change(screen.getByLabelText(/IP address/i), { target: { value: '169.254.169.254' } });
+    fireEvent.click(screen.getByRole('button', { name: '' })); // AddIcon button
+
+    await waitFor(() => expect(screen.getByText('169.254.169.254')).toBeTruthy());
+  });
+
+  it('rejects an invalid IP address', async () => {
+    const service = createMockService({
+      getSettings: vi.fn().mockResolvedValue({ url: SETTINGS_URL }),
+    });
+    render(<SettingsForm ddClient={createMockDockerDesktopClient() as any} service={service} showSnackbar={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByLabelText(/IP address/i)).toBeDefined());
+
+    fireEvent.change(screen.getByLabelText(/IP address/i), { target: { value: 'not-an-ip' } });
+    fireEvent.click(screen.getByRole('button', { name: '' }));
+
+    await waitFor(() => expect(screen.getByText('Enter a valid IPv4 or IPv6 address')).toBeTruthy());
+  });
+
+  it('rejects a duplicate IP address', async () => {
+    const service = createMockService({
+      getSettings: vi.fn().mockResolvedValue({ url: SETTINGS_URL, customIPs: ['169.254.169.254'] }),
+    });
+    render(<SettingsForm ddClient={createMockDockerDesktopClient() as any} service={service} showSnackbar={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByLabelText(/IP address/i)).toBeDefined());
+
+    fireEvent.change(screen.getByLabelText(/IP address/i), { target: { value: '169.254.169.254' } });
+    fireEvent.click(screen.getByRole('button', { name: '' }));
+
+    await waitFor(() => expect(screen.getByText('Address already added')).toBeTruthy());
   });
 
   it('handles unexpected settings response format', async () => {

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Stack, TextField, Typography, Skeleton, Alert } from '@mui/material';
+import {
+  Stack, TextField, Typography, Skeleton, Alert,
+  Chip, Box, IconButton,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import Button from '@mui/material/Button';
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 import { DockerDesktopServiceClient } from '../services/dockerDesktopService';
@@ -41,10 +45,10 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
   const [url, setUrl] = useState('');
   const [urlError, setUrlError] = useState('');
   const [savedUrl, setSavedUrl] = useState('');
-
-  // Keep refs in sync so polling callbacks can read current values without stale closures
-  useEffect(() => { urlRef.current = url; }, [url]);
-  useEffect(() => { savedUrlRef.current = savedUrl; }, [savedUrl]);
+  const [customIPs, setCustomIPs] = useState<string[]>([]);
+  const [savedCustomIPs, setSavedCustomIPs] = useState<string[]>([]);
+  const [newIP, setNewIP] = useState('');
+  const [ipError, setIpError] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [isLoadingSettings, setIsLoadingSettings] = useState(false);
   const [isDebouncing, setIsDebouncing] = useState(false);
@@ -54,6 +58,14 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
   const isMountedRef = useRef(false);
   const urlRef = useRef(url);
   const savedUrlRef = useRef(savedUrl);
+  const customIPsRef = useRef(customIPs);
+  const savedCustomIPsRef = useRef(savedCustomIPs);
+
+  // Keep refs in sync so polling callbacks can read current values without stale closures
+  useEffect(() => { urlRef.current = url; }, [url]);
+  useEffect(() => { savedUrlRef.current = savedUrl; }, [savedUrl]);
+  useEffect(() => { customIPsRef.current = customIPs; }, [customIPs]);
+  useEffect(() => { savedCustomIPsRef.current = savedCustomIPs; }, [savedCustomIPs]);
 
   useEffect(() => {
     if (!ddClient) {
@@ -69,10 +81,13 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
         if (isSettingsResponse(result)) {
           const settings = result;
           const url = settings.url || '';
+          const ips = settings.customIPs || [];
 
           if (isMountedRef.current) {
             setUrl(url);
             setSavedUrl(url);
+            setCustomIPs(ips);
+            setSavedCustomIPs(ips);
           }
         } else if (isMountedRef.current) {
           showSnackbar('Unexpected settings response format', 'error');
@@ -80,9 +95,12 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
       } catch (error) {
         // Silently fall back to localStorage if the backend is unavailable.
         const savedUrl = localStorage.getItem('url') || '';
+        const savedIps = JSON.parse(localStorage.getItem('customIPs') || '[]');
         if (isMountedRef.current) {
           setUrl(savedUrl);
           setSavedUrl(savedUrl);
+          setCustomIPs(savedIps);
+          setSavedCustomIPs(savedIps);
         }
       } finally {
         if (showSkeleton && isMountedRef.current) {
@@ -95,7 +113,9 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
 
     // Poll for external settings changes, but skip if the user has unsaved edits
     const pollInterval = setInterval(() => {
-      if (isMountedRef.current && urlRef.current === savedUrlRef.current) {
+      const urlClean = urlRef.current === savedUrlRef.current;
+      const ipsClean = JSON.stringify(customIPsRef.current) === JSON.stringify(savedCustomIPsRef.current);
+      if (isMountedRef.current && urlClean && ipsClean) {
         loadSettings(false);
       }
     }, 5000);
@@ -105,6 +125,35 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
       clearInterval(pollInterval);
     };
   }, [ddClient, service, showSnackbar]);
+
+  const hasUnsavedChanges = () => {
+    if (url !== savedUrl) return true;
+    if (JSON.stringify(customIPs.slice().sort()) !== JSON.stringify(savedCustomIPs.slice().sort())) return true;
+    return false;
+  };
+
+  const handleAddIP = () => {
+    const trimmed = newIP.trim();
+    if (!trimmed) return;
+
+    // Basic IP validation: try to match IPv4 or IPv6 patterns
+    const ipv4Re = /^(\d{1,3}\.){3}\d{1,3}$/;
+    const ipv6Re = /^[0-9a-fA-F:]+$/;
+    if (!ipv4Re.test(trimmed) && !ipv6Re.test(trimmed)) {
+      setIpError('Enter a valid IPv4 or IPv6 address');
+      return;
+    }
+
+    if (customIPs.includes(trimmed)) {
+      setIpError('Address already added');
+      return;
+    }
+
+    setCustomIPs((prev) => [...prev, trimmed]);
+    setNewIP('');
+    setIpError('');
+    setHasBeenSaved(false);
+  };
 
   const handleSave = async () => {
     // Reset errors
@@ -128,7 +177,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
     setIsSaving(true);
 
     try {
-      const settings = { url };
+      const settings = { url, customIPs };
 
       await withTimeout(
         ddClient.extension.vm?.service?.post('/settings', settings) ?? Promise.resolve(),
@@ -137,9 +186,11 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
 
       // Save settings locally after successful backend save
       localStorage.setItem('url', url);
+      localStorage.setItem('customIPs', JSON.stringify(customIPs));
 
       // Update saved state to disable button
       setSavedUrl(url);
+      setSavedCustomIPs([...customIPs]);
       setHasBeenSaved(true);
       showSnackbar('Settings saved', 'success');
 
@@ -200,11 +251,54 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
             fullWidth
             spellCheck={false}
           />
+
+          <Typography variant="subtitle2" sx={{ mt: 2 }}>IMDS Addresses</Typography>
+          <Typography variant="caption" color="text.secondary">
+            IP addresses to intercept (IPv4 or IPv6).
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1 }}>
+            {customIPs.map((ip) => (
+              <Chip
+                key={ip}
+                label={ip}
+                size="small"
+                onDelete={() => {
+                  setCustomIPs((prev) => prev.filter((i) => i !== ip));
+                  setHasBeenSaved(false);
+                }}
+              />
+            ))}
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+            <TextField
+              type="text"
+              label="IP address"
+              placeholder="e.g. 10.0.0.1 or fd00::1"
+              value={newIP}
+              onChange={(e) => { setNewIP(e.target.value); setIpError(''); }}
+              variant="outlined"
+              size="small"
+              error={!!ipError}
+              helperText={ipError}
+              spellCheck={false}
+              sx={{ flex: 1 }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddIP();
+                }
+              }}
+            />
+            <IconButton onClick={handleAddIP} size="small" sx={{ mt: 0.5 }}>
+              <AddIcon />
+            </IconButton>
+          </Box>
+
           <Button
             variant="contained"
             onClick={handleSave}
-            disabled={isSaving || url === savedUrl || isDebouncing || proxyUnreachable}
-            sx={{ alignSelf: 'flex-start' }}
+            disabled={isSaving || !hasUnsavedChanges() || isDebouncing || proxyUnreachable}
+            sx={{ alignSelf: 'flex-start', mt: 1 }}
           >
             {isSaving ? 'Saving...' : hasBeenSaved ? 'Saved' : 'Save Settings'}
           </Button>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -36,6 +36,7 @@ export interface ContainerInfo {
  */
 export interface SettingsResponse {
   url?: string;
+  customIPs?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the hard-coded provider registry with a user-editable list of IPv4/IPv6 addresses in the Settings tab. The backend derives subnets and Docker bridge networks from those addresses at runtime; networks are no longer defined in docker-compose.yaml.

- Remove EnabledProviders, providerRegistry, and the provider-checkbox UI; replace with a free-form IP list
- computeNetworkConfig groups configured IPs by /24 (IPv4) or /64 (IPv6) subnet
- reconcileNetworks runs on backend startup and on every Settings save; networks whose subnets no longer match desired are removed and recreated
- Fix disconnectAllFromNetwork comparing network names against IDs, which left stale endpoints and blocked network removal
- Update scripts/test-e2e.sh to configure IPs via /settings

### Breaking change

Existing installs that relied on the AWS / GCP / OpenStack default networks will start with an empty IP list and must add the addresses they need in the Settings tab.

## Test plan

- [x] make test (backend 82.3% / proxy 84.3% / UI passes thresholds)
- [x] Manual: add IP -> network created; remove IP -> network removed; change subnet -> network recreated
- [ ] make test-e2e against live extension