### PR TITLE
feat: replace provider pills with per-IP network chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Any IPv4 or IPv6 address you add in Settings is intercepted. These are the well-
 
 Two services run inside the Docker Desktop VM:
 
-- The **controller** watches Docker events and manages a Docker bridge network for each /24 (IPv4) or /64 (IPv6) subnet covering the addresses you configured. When a labeled container starts, it briefly pauses it, connects it to those networks, then unpauses it - ensuring the network is ready before the container's process starts.
+- The **controller** watches Docker events and creates one Docker bridge network per /24 (IPv4) or /64 (IPv6) subnet, named after the subnet (e.g. `.imds-169.254.169.0`). When a labeled container starts, it briefly pauses it, connects it to those networks, then unpauses it - ensuring the network is ready before the container's process starts.
 - The **proxy** binds to the configured IMDS addresses and forwards requests to your server, adding `X-Container-Id`, `X-Container-Name`, and container label headers so your server knows which container made the request.
 
 For the full technical description, see [docs/architecture.md](docs/architecture.md).

--- a/backend/handlers_echo_test.go
+++ b/backend/handlers_echo_test.go
@@ -190,14 +190,20 @@ func TestSaveSettingsWithCustomIPs(t *testing.T) {
 	nets := settings.NetworkConfig
 	settingsMutex.RUnlock()
 
-	if len(nets) != 1 {
-		t.Fatalf("want 1 network config, got %d", len(nets))
+	if len(nets) != 2 {
+		t.Fatalf("want 2 network configs, got %d", len(nets))
 	}
 	if nets[0].ProxyIPv4 != "169.254.169.254" {
-		t.Errorf("want ProxyIPv4 169.254.169.254, got %q", nets[0].ProxyIPv4)
+		t.Errorf("want nets[0].ProxyIPv4 169.254.169.254, got %q", nets[0].ProxyIPv4)
 	}
-	if nets[0].ProxyIPv6 != "fd00:ec2::254" {
-		t.Errorf("want ProxyIPv6 fd00:ec2::254, got %q", nets[0].ProxyIPv6)
+	if nets[0].Name != ".imds-169.254.169.0" {
+		t.Errorf("want nets[0].Name .imds-169.254.169.0, got %q", nets[0].Name)
+	}
+	if nets[1].ProxyIPv6 != "fd00:ec2::254" {
+		t.Errorf("want nets[1].ProxyIPv6 fd00:ec2::254, got %q", nets[1].ProxyIPv6)
+	}
+	if nets[1].Name != ".imds-fd00-ec2--" {
+		t.Errorf("want nets[1].Name .imds-fd00-ec2--, got %q", nets[1].Name)
 	}
 }
 
@@ -404,13 +410,15 @@ func TestGetContainersWithData(t *testing.T) {
 	}
 	trackedContainersMutex.Unlock()
 
-	managedNetworksMutex.Lock()
-	managedNetworks = []ImdsNetwork{{NetworkName: ".imds-0", Providers: map[string][]string{"AWS": {"v4", "v6"}, "GCP": {"v4", "v6"}}}}
-	managedNetworksMutex.Unlock()
+	settingsMutex.Lock()
+	settings.CustomIPs = []string{"169.254.169.254"}
+	settings.NetworkConfig = []NetworkConfig{{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254"}}
+	settingsMutex.Unlock()
 	t.Cleanup(func() {
-		managedNetworksMutex.Lock()
-		managedNetworks = nil
-		managedNetworksMutex.Unlock()
+		settingsMutex.Lock()
+		settings.CustomIPs = nil
+		settings.NetworkConfig = nil
+		settingsMutex.Unlock()
 	})
 
 	e := echo.New()
@@ -433,17 +441,104 @@ func TestGetContainersWithData(t *testing.T) {
 	if len(result.Containers) != 1 {
 		t.Fatalf("want 1 container, got %d", len(result.Containers))
 	}
-	if len(result.Containers[0].Providers) != 2 {
-		t.Fatalf("want 2 providers (AWS, GCP), got %d", len(result.Containers[0].Providers))
+	if len(result.Containers[0].Addresses) != 1 {
+		t.Fatalf("want 1 address, got %d", len(result.Containers[0].Addresses))
 	}
-	awsConnected := false
-	for _, p := range result.Containers[0].Providers {
-		if p.Name == "AWS" && p.IPv4Connected && p.IPv6Connected {
-			awsConnected = true
+	addr := result.Containers[0].Addresses[0]
+	if addr.IP != "169.254.169.254" || !addr.Connected {
+		t.Errorf("want 169.254.169.254 connected, got %+v", addr)
+	}
+}
+
+func TestBuildAddressStatusesConnected(t *testing.T) {
+	nets := []NetworkInfo{{NetworkName: ".imds-0"}}
+	cfg := []NetworkConfig{{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254"}}
+	ips := []string{"169.254.169.254"}
+
+	got := buildAddressStatuses(nets, cfg, ips)
+	if len(got) != 1 {
+		t.Fatalf("want 1 address, got %d", len(got))
+	}
+	if got[0].IP != "169.254.169.254" || !got[0].Connected {
+		t.Errorf("want {169.254.169.254, true}, got %+v", got[0])
+	}
+}
+
+func TestBuildAddressStatusesNotConnected(t *testing.T) {
+	nets := []NetworkInfo{} // container not on any IMDS network
+	cfg := []NetworkConfig{{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254"}}
+	ips := []string{"169.254.169.254"}
+
+	got := buildAddressStatuses(nets, cfg, ips)
+	if len(got) != 1 {
+		t.Fatalf("want 1 address, got %d", len(got))
+	}
+	if got[0].Connected {
+		t.Errorf("want not connected, got %+v", got[0])
+	}
+}
+
+func TestBuildAddressStatusesIPv6(t *testing.T) {
+	nets := []NetworkInfo{{NetworkName: ".imds-0"}}
+	cfg := []NetworkConfig{{Name: ".imds-0", IPv6Subnet: "fd00:ec2::/64", ProxyIPv6: "fd00:ec2::254"}}
+	ips := []string{"fd00:ec2::254"}
+
+	got := buildAddressStatuses(nets, cfg, ips)
+	if len(got) != 1 || !got[0].Connected {
+		t.Errorf("want IPv6 connected, got %+v", got)
+	}
+}
+
+func TestBuildAddressStatusesMultiple(t *testing.T) {
+	nets := []NetworkInfo{{NetworkName: ".imds-0"}}
+	cfg := []NetworkConfig{
+		{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254", IPv6Subnet: "fd00:ec2::/64", ProxyIPv6: "fd00:ec2::254"},
+	}
+	ips := []string{"169.254.169.254", "fd00:ec2::254"}
+
+	got := buildAddressStatuses(nets, cfg, ips)
+	if len(got) != 2 {
+		t.Fatalf("want 2 addresses, got %d", len(got))
+	}
+	for _, s := range got {
+		if !s.Connected {
+			t.Errorf("want %s connected, got not connected", s.IP)
 		}
 	}
-	if !awsConnected {
-		t.Errorf("want AWS provider with IPv4+IPv6 connected for .imds-0")
+}
+
+func TestBuildAddressStatusesNoConfig(t *testing.T) {
+	nets := []NetworkInfo{{NetworkName: ".imds-0"}}
+	got := buildAddressStatuses(nets, nil, []string{"169.254.169.254"})
+	if len(got) != 1 || got[0].Connected {
+		t.Errorf("want not connected when no network config, got %+v", got)
+	}
+}
+
+func TestIpInNetworkConfigIPv4(t *testing.T) {
+	cfg := NetworkConfig{IPv4Subnet: "169.254.169.0/24"}
+	if !ipInNetworkConfig("169.254.169.254", cfg) {
+		t.Error("want 169.254.169.254 in 169.254.169.0/24")
+	}
+	if ipInNetworkConfig("10.0.0.1", cfg) {
+		t.Error("want 10.0.0.1 not in 169.254.169.0/24")
+	}
+}
+
+func TestIpInNetworkConfigIPv6(t *testing.T) {
+	cfg := NetworkConfig{IPv6Subnet: "fd00:ec2::/64"}
+	if !ipInNetworkConfig("fd00:ec2::254", cfg) {
+		t.Error("want fd00:ec2::254 in fd00:ec2::/64")
+	}
+	if ipInNetworkConfig("fd00:a9fe::/64", cfg) {
+		t.Error("want fd00:a9fe:: not in fd00:ec2::/64")
+	}
+}
+
+func TestIpInNetworkConfigInvalidIP(t *testing.T) {
+	cfg := NetworkConfig{IPv4Subnet: "169.254.169.0/24"}
+	if ipInNetworkConfig("not-an-ip", cfg) {
+		t.Error("want invalid IP to return false")
 	}
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -47,7 +46,6 @@ var logger = logrus.New()
 const (
 	proxySocketPath    = "/var/run/imds-proxy/backend.sock"
 	imdsManagedLabel   = "imds-proxy.managed"
-	imdsProvidersLabel = "imds-proxy.providers"
 	proxyContainerName = "imds-proxy"
 )
 
@@ -77,19 +75,24 @@ type NetworkConfig struct {
 	IPv6Subnet string `json:"ipv6Subnet,omitempty"`
 	ProxyIPv4  string `json:"proxyIPv4,omitempty"`
 	ProxyIPv6  string `json:"proxyIPv6,omitempty"`
-	Providers  string `json:"providers"`
+}
+
+// subnetToNetworkName converts a subnet CIDR string to a Docker network name.
+// e.g. "169.254.169.0/24" → ".imds-169.254.169.0", "fd00:ec2::/64" → ".imds-fd00-ec2--"
+func subnetToNetworkName(subnet string) string {
+	if i := strings.Index(subnet, "/"); i != -1 {
+		subnet = subnet[:i]
+	}
+	subnet = strings.ReplaceAll(subnet, ":", "-")
+	return ".imds-" + subnet
 }
 
 // computeNetworkConfig derives the Docker network configuration needed to
-// handle the given IMDS addresses. Each bridge network supports at most one
-// IPv4 subnet and one IPv6 subnet, so addresses are grouped by subnet.
+// handle the given IMDS addresses. Each subnet gets its own bridge network,
+// named after the subnet for stability across add/remove operations.
 func computeNetworkConfig(ips []string) []NetworkConfig {
-	type subnetInfo struct {
-		subnet  string
-		proxyIP string
-		isIPv6  bool
-	}
-	seen := make(map[string]subnetInfo)
+	seen := make(map[string]bool)
+	var configs []NetworkConfig
 
 	for _, ip := range ips {
 		ip = strings.TrimSpace(ip)
@@ -100,52 +103,37 @@ func computeNetworkConfig(ips []string) []NetworkConfig {
 		if parsed == nil {
 			continue
 		}
+		var cfg NetworkConfig
+		var subnetStr string
 		if parsed.To4() != nil {
 			v4 := parsed.To4()
 			subnet := net.IPNet{IP: net.IPv4(v4[0], v4[1], v4[2], 0), Mask: net.CIDRMask(24, 32)}
-			subnetStr := subnet.String()
-			if _, exists := seen[subnetStr]; !exists {
-				seen[subnetStr] = subnetInfo{subnet: subnetStr, proxyIP: ip, isIPv6: false}
+			subnetStr = subnet.String()
+			if seen[subnetStr] {
+				continue
+			}
+			cfg = NetworkConfig{
+				Name:       subnetToNetworkName(subnetStr),
+				IPv4Subnet: subnetStr,
+				ProxyIPv4:  ip,
 			}
 		} else {
 			v6 := parsed.To16()
 			prefix := make(net.IP, 16)
 			copy(prefix, v6[:8])
 			subnet := net.IPNet{IP: prefix, Mask: net.CIDRMask(64, 128)}
-			subnetStr := subnet.String()
-			if _, exists := seen[subnetStr]; !exists {
-				seen[subnetStr] = subnetInfo{subnet: subnetStr, proxyIP: ip, isIPv6: true}
+			subnetStr = subnet.String()
+			if seen[subnetStr] {
+				continue
+			}
+			cfg = NetworkConfig{
+				Name:       subnetToNetworkName(subnetStr),
+				IPv6Subnet: subnetStr,
+				ProxyIPv6:  ip,
 			}
 		}
-	}
-
-	var v4Subnets, v6Subnets []string
-	for key, info := range seen {
-		if info.isIPv6 {
-			v6Subnets = append(v6Subnets, key)
-		} else {
-			v4Subnets = append(v4Subnets, key)
-		}
-	}
-	sort.Strings(v4Subnets)
-	sort.Strings(v6Subnets)
-
-	var configs []NetworkConfig
-	netIndex := 0
-	for i := 0; i < len(v4Subnets) || i < len(v6Subnets); i++ {
-		cfg := NetworkConfig{Name: fmt.Sprintf(".imds-%d", netIndex)}
-		if i < len(v4Subnets) {
-			v4 := seen[v4Subnets[i]]
-			cfg.IPv4Subnet = v4.subnet
-			cfg.ProxyIPv4 = v4.proxyIP
-		}
-		if i < len(v6Subnets) {
-			v6 := seen[v6Subnets[i]]
-			cfg.IPv6Subnet = v6.subnet
-			cfg.ProxyIPv6 = v6.proxyIP
-		}
+		seen[subnetStr] = true
 		configs = append(configs, cfg)
-		netIndex++
 	}
 	return configs
 }
@@ -165,20 +153,11 @@ type NetworkInfo struct {
 	NetworkName string `json:"networkName"`
 }
 
-// ImdsNetwork is the internal representation of a managed IMDS network.
-// Providers maps provider name (e.g. "AWS") to the protocols it carries on
-// this network (e.g. ["v4", "v6"]).
-type ImdsNetwork struct {
-	NetworkName string
-	Providers   map[string][]string
-}
-
-// ProviderStatus is the per-container API representation of a cloud provider's
-// proxying state across all managed networks.
-type ProviderStatus struct {
-	Name          string `json:"name"`
-	IPv4Connected bool   `json:"ipv4Connected"`
-	IPv6Connected bool   `json:"ipv6Connected"`
+// AddressStatus is the per-container API representation of a single configured
+// IMDS IP address's connectivity state.
+type AddressStatus struct {
+	IP        string `json:"ip"`
+	Connected bool   `json:"connected"`
 }
 
 type ContainerInfo struct {
@@ -186,7 +165,7 @@ type ContainerInfo struct {
 	Name        string            `json:"name"`
 	Labels      map[string]string `json:"labels"`
 	Networks    []NetworkInfo     `json:"-"`
-	Providers   []ProviderStatus  `json:"providers"`
+	Addresses   []AddressStatus   `json:"addresses"`
 }
 
 type ContainersAPIResponse struct {
@@ -206,7 +185,7 @@ var (
 	ipToContainerID      = make(map[string]string)
 	ipToContainerIDMutex sync.RWMutex
 
-	managedNetworks      []ImdsNetwork
+	managedNetworks      []string
 	managedNetworksMutex sync.RWMutex
 
 	dockerClient DockerClient
@@ -512,7 +491,11 @@ func loadSettings() error {
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			logger.Infof("Settings file does not exist, starting with empty settings")
+			logger.Infof("Settings file does not exist, starting with defaults")
+			settingsMutex.Lock()
+			settings.CustomIPs = []string{"169.254.169.254"}
+			settings.NetworkConfig = computeNetworkConfig(settings.CustomIPs)
+			settingsMutex.Unlock()
 			return nil
 		}
 		return err
@@ -772,9 +755,9 @@ func addContainerToTrackingWithNetwork(ctx context.Context, cli DockerClient, co
 	managedNetworksMutex.RUnlock()
 
 	networksToConnect := []string{}
-	for _, mn := range knownNetworks {
-		if !connectedNetworks[mn.NetworkName] {
-			networksToConnect = append(networksToConnect, mn.NetworkName)
+	for _, networkName := range knownNetworks {
+		if !connectedNetworks[networkName] {
+			networksToConnect = append(networksToConnect, networkName)
 		}
 	}
 
@@ -887,76 +870,49 @@ func refreshContainerNetworks(ctx context.Context, cli DockerClient, containerID
 	return nil
 }
 
-// parseProviderLabel parses the imds-proxy.providers label value into a map
-// of provider name to the protocols it carries on that network.
-// Format: "AWS=v4,v6;GCP=v4,v6;OpenStack=v4"
-func parseProviderLabel(s string) map[string][]string {
-	result := make(map[string][]string)
-	for _, entry := range strings.Split(s, ";") {
-		entry = strings.TrimSpace(entry)
-		if entry == "" {
-			continue
-		}
-		parts := strings.SplitN(entry, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		name := strings.TrimSpace(parts[0])
-		protos := []string{}
-		for _, p := range strings.Split(parts[1], ",") {
-			p = strings.TrimSpace(p)
-			if p != "" {
-				protos = append(protos, p)
-			}
-		}
-		if name != "" {
-			result[name] = protos
-		}
+// ipInNetworkConfig reports whether ip falls within the subnet covered by cfg.
+func ipInNetworkConfig(ip string, cfg NetworkConfig) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
 	}
-	return result
+	if parsed.To4() != nil {
+		if cfg.IPv4Subnet == "" {
+			return false
+		}
+		_, subnet, err := net.ParseCIDR(cfg.IPv4Subnet)
+		if err != nil {
+			return false
+		}
+		return subnet.Contains(parsed)
+	}
+	if cfg.IPv6Subnet == "" {
+		return false
+	}
+	_, subnet, err := net.ParseCIDR(cfg.IPv6Subnet)
+	if err != nil {
+		return false
+	}
+	return subnet.Contains(parsed)
 }
 
-// buildProviderStatuses aggregates per-provider connectivity across all managed
-// networks, given the set of networks the container is currently connected to.
-func buildProviderStatuses(containerNetworks []NetworkInfo, managedNets []ImdsNetwork) []ProviderStatus {
+// buildAddressStatuses returns one AddressStatus per configured IP, reporting
+// whether the container is connected to the network that covers that address.
+func buildAddressStatuses(containerNetworks []NetworkInfo, netConfig []NetworkConfig, ips []string) []AddressStatus {
 	connectedNames := make(map[string]bool, len(containerNetworks))
 	for _, n := range containerNetworks {
 		connectedNames[n.NetworkName] = true
 	}
-
-	// Collect which protocols are connected per provider
-	connectedProtos := make(map[string]map[string]bool)
-	// Track all known provider names (to include disconnected ones)
-	allProviders := make(map[string]bool)
-
-	for _, mn := range managedNets {
-		connected := connectedNames[mn.NetworkName]
-		for provider, protos := range mn.Providers {
-			allProviders[provider] = true
-			if connected {
-				if connectedProtos[provider] == nil {
-					connectedProtos[provider] = make(map[string]bool)
-				}
-				for _, proto := range protos {
-					connectedProtos[provider][proto] = true
-				}
+	statuses := make([]AddressStatus, 0, len(ips))
+	for _, ip := range ips {
+		connected := false
+		for _, cfg := range netConfig {
+			if ipInNetworkConfig(ip, cfg) {
+				connected = connectedNames[cfg.Name]
+				break
 			}
 		}
-	}
-
-	names := make([]string, 0, len(allProviders))
-	for name := range allProviders {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	statuses := make([]ProviderStatus, 0, len(names))
-	for _, name := range names {
-		statuses = append(statuses, ProviderStatus{
-			Name:          name,
-			IPv4Connected: connectedProtos[name]["v4"],
-			IPv6Connected: connectedProtos[name]["v6"],
-		})
+		statuses = append(statuses, AddressStatus{IP: ip, Connected: connected})
 	}
 	return statuses
 }
@@ -969,12 +925,9 @@ func discoverManagedNetworks(ctx context.Context, cli DockerClient) error {
 		return err
 	}
 
-	discovered := make([]ImdsNetwork, 0, len(networkList))
+	discovered := make([]string, 0, len(networkList))
 	for _, n := range networkList {
-		discovered = append(discovered, ImdsNetwork{
-			NetworkName: n.Name,
-			Providers:   parseProviderLabel(n.Labels[imdsProvidersLabel]),
-		})
+		discovered = append(discovered, n.Name)
 	}
 
 	managedNetworksMutex.Lock()
@@ -1053,8 +1006,7 @@ func reconcileNetworks(ctx context.Context, cli DockerClient, desired []NetworkC
 				Config: ipamConfigs,
 			},
 			Labels: map[string]string{
-				imdsManagedLabel:   "true",
-				imdsProvidersLabel: d.Providers,
+				imdsManagedLabel: "true",
 			},
 		}
 		if _, err := cli.NetworkCreate(ctx, d.Name, opts); err != nil {
@@ -1154,13 +1106,14 @@ func getContainers(ctx echo.Context) error {
 	trackedContainersMutex.RLock()
 	defer trackedContainersMutex.RUnlock()
 
-	managedNetworksMutex.RLock()
-	networks := managedNetworks
-	managedNetworksMutex.RUnlock()
+	settingsMutex.RLock()
+	netConfig := settings.NetworkConfig
+	customIPs := settings.CustomIPs
+	settingsMutex.RUnlock()
 
 	containerList := make([]ContainerInfo, 0, len(trackedContainers))
 	for _, info := range trackedContainers {
-		info.Providers = buildProviderStatuses(info.Networks, networks)
+		info.Addresses = buildAddressStatuses(info.Networks, netConfig, customIPs)
 		containerList = append(containerList, info)
 	}
 

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -171,10 +171,7 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 	defer resetTracking()
 
 	managedNetworksMutex.Lock()
-	managedNetworks = []ImdsNetwork{
-		{NetworkName: ".imds-0", Providers: map[string][]string{"AWS": {"v4", "v6"}}},
-		{NetworkName: ".imds-1", Providers: map[string][]string{"OpenStack": {"v6"}}},
-	}
+	managedNetworks = []string{".imds-0", ".imds-1"}
 	managedNetworksMutex.Unlock()
 	defer func() {
 		managedNetworksMutex.Lock()
@@ -266,9 +263,7 @@ func TestAddContainerToTrackingWithNetworkPauseFirst(t *testing.T) {
 	defer resetTracking()
 
 	managedNetworksMutex.Lock()
-	managedNetworks = []ImdsNetwork{
-		{NetworkName: ".imds-0", Providers: map[string][]string{"AWS": {"v4", "v6"}}},
-	}
+	managedNetworks = []string{".imds-0"}
 	managedNetworksMutex.Unlock()
 	defer func() {
 		managedNetworksMutex.Lock()
@@ -1155,19 +1150,14 @@ func TestDiscoverManagedNetworksEmpty(t *testing.T) {
 	}
 }
 
-func TestDiscoverManagedNetworksWithProviders(t *testing.T) {
+func TestDiscoverManagedNetworksWithNetworks(t *testing.T) {
 	resetManagedNetworks()
 	t.Cleanup(resetManagedNetworks)
 
 	cli := &fakeDockerClient{
 		networkList: []network.Summary{
-			{
-				Name: ".imds-0",
-				Labels: map[string]string{
-					"imds-proxy.managed":   "true",
-					"imds-proxy.providers": "AWS=v4,v6;GCP=v4,v6;OpenStack=v4",
-				},
-			},
+			{Name: ".imds-0", Labels: map[string]string{"imds-proxy.managed": "true"}},
+			{Name: ".imds-1", Labels: map[string]string{"imds-proxy.managed": "true"}},
 		},
 	}
 
@@ -1179,22 +1169,17 @@ func TestDiscoverManagedNetworksWithProviders(t *testing.T) {
 	nets := managedNetworks
 	managedNetworksMutex.RUnlock()
 
-	if len(nets) != 1 {
-		t.Fatalf("want 1 managed network, got %d", len(nets))
+	if len(nets) != 2 {
+		t.Fatalf("want 2 managed networks, got %d", len(nets))
 	}
-	if nets[0].NetworkName != ".imds-0" {
-		t.Errorf("want network name .imds-0, got %s", nets[0].NetworkName)
+	found := map[string]bool{}
+	for _, name := range nets {
+		found[name] = true
 	}
-	if len(nets[0].Providers) != 3 {
-		t.Fatalf("want 3 providers, got %d", len(nets[0].Providers))
-	}
-	for _, name := range []string{"AWS", "GCP", "OpenStack"} {
-		if _, ok := nets[0].Providers[name]; !ok {
-			t.Errorf("want provider %s in Providers map, got %v", name, nets[0].Providers)
+	for _, want := range []string{".imds-0", ".imds-1"} {
+		if !found[want] {
+			t.Errorf("want network %s in managed networks, got %v", want, nets)
 		}
-	}
-	if got := nets[0].Providers["AWS"]; len(got) != 2 || got[0] != "v4" || got[1] != "v6" {
-		t.Errorf("want AWS=[v4 v6], got %v", got)
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ If the configured URL uses `localhost`, the proxy rewrites it to `host.docker.in
 
 ## Networks
 
-Bridge networks are derived from the IP addresses configured in Settings. The controller groups configured IPs by /24 (IPv4) or /64 (IPv6) subnet and creates one bridge network per subnet pair (`.imds-0`, `.imds-1`, ...). Each network has the proxy attached at the configured IP, so any container connected to that network reaches the proxy when it hits the IMDS address.
+Bridge networks are derived from the IP addresses configured in Settings. The controller creates one bridge network per /24 (IPv4) or /64 (IPv6) subnet. Networks are named after their subnet — e.g. `.imds-169.254.169.0` for the `169.254.169.254` address. Each network has the proxy attached at the configured IP, so any container connected to that network reaches the proxy when it hits the IMDS address. Because names are derived from subnet content, adding or removing an IP never renames an existing network, which avoids brief connectivity interruptions for containers on unrelated subnets.
 
 The controller reconciles networks on backend startup and after every Settings save:
 

--- a/docs/manual-test-plan.md
+++ b/docs/manual-test-plan.md
@@ -74,7 +74,7 @@ docker run -d --rm --name test-imds-2 --label imds-proxy.enabled=true alpine sle
 
 | # | Action | Expected |
 |---|--------|----------|
-| 4.1 | Containers appear in the table | Row shows container name, truncated ID, and a collapse arrow |
+| 4.1 | Containers appear in the table | Row shows container name, truncated ID, per-IP address chips, and a collapse arrow |
 | 4.2 | | Item count at bottom-right updates |
 | 4.3 | Hover a row | Name copy icon and ID copy icon appear |
 | 4.4 | Click name copy icon | Snackbar "Copied container name to clipboard"; clipboard contains the name |
@@ -99,17 +99,26 @@ docker run -d --rm --name test-imds-2 --label imds-proxy.enabled=true alpine sle
 
 ---
 
-## 5. Network attachment
+## 5. Network connectivity chips
 
-Confirm a labeled container is attached to the IMDS networks the controller managed for the addresses configured in Settings:
+Requires the containers from section 4 and at least one IP configured in Settings (e.g. `169.254.169.254`).
+
+| # | Action | Expected |
+|---|--------|----------|
+| 5.1 | Observe the "Networks" column for a running labeled container | One chip per configured IP address |
+| 5.2 | | Connected addresses show a green outlined chip |
+| 5.3 | | Disconnected addresses show a grey outlined chip |
+| 5.4 | Hover a chip | Tooltip reads "Connected" or "Not connected" |
+| 5.5 | Stop the proxy container (`docker stop imds-proxy`) | Chips may turn grey (container still tracked but proxy not routing) |
+| 5.6 | Start the proxy again | Chips return to green after the next poll |
+
+To confirm network attachment via CLI:
 
 ```shell
 docker inspect test-imds-1 --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}'
 ```
 
-Expected output contains one `.imds-N` network per /24 IPv4 subnet and per /64 IPv6 subnet covering the configured IPs (typically `.imds-0` when only `169.254.169.254` is configured).
-
-> Per-container connectivity status (provider pills) is not currently rendered — see TODO.md "Container list UI redesign".
+Expected output contains one network per configured IP subnet: `.imds-169.254.169.0` for `169.254.169.254`, `.imds-fd00-ec2--` for `fd00:ec2::254`, etc.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -47,13 +47,13 @@ docker inspect <container-name> --format '{{index .Config.Labels "imds-proxy.ena
 
 Should output `true`.
 
-**Check network attachment.** The container should be connected to both IMDS networks. The provider pills in the UI show this at a glance. To check directly:
+**Check network attachment.** The Networks column in the Containers tab shows a chip per configured IP — green means connected. To check directly:
 
 ```bash
 docker inspect <container-name> --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}'
 ```
 
-Look for names ending in `.imds-0` and `.imds-1`.
+Look for names starting with `.imds-` (e.g. `.imds-169.254.169.0`).
 
 **Check the IMDS address is reachable from the container.**
 
@@ -67,19 +67,17 @@ If that times out but the container is attached to the IMDS network, the proxy m
 
 ---
 
-## Provider pills are yellow or red
+## Network chips are grey
 
-Yellow means one IMDS network is connected but not the other. Red means neither is connected.
+Grey means the container is not connected to that IMDS network. This usually happens right after a container starts (the controller hasn't finished attaching it yet) or if a network was manually disconnected.
 
-This usually happens right after a container starts (the controller hasn't finished attaching it yet) or if a network was manually disconnected.
-
-If the pills stay red after a minute, check whether the IMDS networks exist:
+If the chips stay grey after a minute, check whether the IMDS networks exist:
 
 ```bash
 docker network ls | grep imds
 ```
 
-You should see two networks with names ending in `.imds-0` and `.imds-1`. If they're missing, reinstalling the extension will recreate them.
+You should see one network per configured IP address (e.g. `.imds-169.254.169.0`). If they're missing, reinstalling the extension will recreate them.
 
 ---
 

--- a/ui/src/__tests__/testHelpers.ts
+++ b/ui/src/__tests__/testHelpers.ts
@@ -58,10 +58,9 @@ export const createMockContainer = (overrides?: Partial<ContainerInfo>): Contain
   containerId: 'abc123def456ghi789jkl012mno345pqr678',
   name: '/test-container',
   labels: { ...TEST_LABELS },
-  providers: [
-    { name: 'AWS', ipv4Connected: true, ipv6Connected: true },
-    { name: 'GCP', ipv4Connected: true, ipv6Connected: true },
-    { name: 'OpenStack', ipv4Connected: true, ipv6Connected: true },
+  addresses: [
+    { ip: '169.254.169.254', connected: true },
+    { ip: 'fd00:ec2::254', connected: true },
   ],
   ...overrides,
 });
@@ -74,10 +73,9 @@ export const createMockContainers = (count: number = 3): ContainerInfo[] => {
     containerId: `container-id-${i.toString().padStart(32, '0')}`,
     name: `/container-${i}`,
     labels: { ...TEST_LABELS },
-    providers: [
-      { name: 'AWS', ipv4Connected: true, ipv6Connected: true },
-      { name: 'GCP', ipv4Connected: true, ipv6Connected: true },
-      { name: 'OpenStack', ipv4Connected: true, ipv6Connected: true },
+    addresses: [
+      { ip: '169.254.169.254', connected: true },
+      { ip: 'fd00:ec2::254', connected: true },
     ],
   }));
 };

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -36,7 +36,7 @@ import {
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import { ContainerInfo, isProviderFullyConnected, isProviderPartiallyConnected } from '../types';
+import { ContainerInfo } from '../types';
 import { CONTAINER_ID_DISPLAY_LENGTH } from '../constants';
 import { cleanContainerName } from '../utils/containerUtils';
 
@@ -141,7 +141,7 @@ export function ContainersTable({
                   Container ID
                 </TableSortLabel>
               </TableCell>
-              <TableCell>Providers</TableCell>
+              <TableCell>Networks</TableCell>
               <TableCell padding="checkbox" />
             </TableRow>
           </TableHead>
@@ -226,39 +226,21 @@ export function ContainersTable({
                     </TableCell>
                     <TableCell>
                       <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                        {[...container.providers]
-                          .sort((a, b) => a.name.localeCompare(b.name))
-                          .map((p) => {
-                            const full = isProviderFullyConnected(p);
-                            const partial = isProviderPartiallyConnected(p);
-                            const color = full ? 'success' : partial ? 'warning' : 'error';
-                            const tooltipContent = (
-                              <Box>
-                                <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                                  {p.name}
-                                </Typography>
-                                <Box component="div">
-                                  <Typography variant="caption" display="block">
-                                    {p.ipv4Connected ? '✓' : '✗'} IPv4
-                                  </Typography>
-                                  <Typography variant="caption" display="block">
-                                    {p.ipv6Connected ? '✓' : '✗'} IPv6
-                                  </Typography>
-                                </Box>
-                              </Box>
-                            );
-                            return (
-                              <Tooltip key={p.name} title={tooltipContent}>
-                                <Chip
-                                  label={p.name}
-                                  color={color}
-                                  size="small"
-                                  variant="outlined"
-                                  tabIndex={0}
-                                />
-                              </Tooltip>
-                            );
-                          })}
+                        {container.addresses.map((a) => (
+                          <Tooltip
+                            key={a.ip}
+                            title={a.connected ? 'Connected' : 'Not connected'}
+                          >
+                            <Chip
+                              label={a.ip}
+                              color={a.connected ? 'success' : 'default'}
+                              size="small"
+                              variant="outlined"
+                              tabIndex={0}
+                              sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}
+                            />
+                          </Tooltip>
+                        ))}
                       </Stack>
                     </TableCell>
                     <TableCell padding="checkbox">

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -273,7 +273,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
             <TextField
               type="text"
               label="IP address"
-              placeholder="e.g. 10.0.0.1 or fd00::1"
+              placeholder="e.g. 169.254.169.254 or fd00:ec2::254"
               value={newIP}
               onChange={(e) => { setNewIP(e.target.value); setIpError(''); }}
               variant="outlined"

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 /**
- * Per-provider IMDS proxying status for a container
+ * Connectivity status for a single configured IMDS IP address
  */
-export interface ProviderStatus {
-  name: string;
-  ipv4Connected: boolean;
-  ipv6Connected: boolean;
+export interface AddressStatus {
+  ip: string;
+  connected: boolean;
 }
 
 /**
@@ -28,7 +27,7 @@ export interface ContainerInfo {
   containerId: string;
   name: string;
   labels: Record<string, string>;
-  providers: ProviderStatus[];
+  addresses: AddressStatus[];
 }
 
 /**
@@ -69,15 +68,3 @@ export const isContainersResponse = (value: unknown): value is ContainersRespons
   const v = value as Record<string, unknown>;
   return Array.isArray(v.containers) && typeof v.proxyStatus === 'string';
 };
-
-/**
- * Returns true if the provider has full proxying (both IPv4 and IPv6)
- */
-export const isProviderFullyConnected = (p: ProviderStatus): boolean =>
-  p.ipv4Connected && p.ipv6Connected;
-
-/**
- * Returns true if the provider has partial proxying (one of IPv4/IPv6)
- */
-export const isProviderPartiallyConnected = (p: ProviderStatus): boolean =>
-  p.ipv4Connected !== p.ipv6Connected;


### PR DESCRIPTION
## Summary

- Replaces the old provider-based status column with a per-IP chip in the Networks column — one chip per configured address, green=connected, grey=not connected
- Networks are now named after their subnet (e.g. `.imds-169.254.169.0`) instead of sequential `.imds-N`, so adding or removing an IP never renames an existing network and avoids brief disconnects for unrelated containers
- IPv4 and IPv6 addresses each get their own network instead of being paired on the same bridge
- `169.254.169.254` is pre-populated on first run (no settings file); removing it and saving respects the user's choice

## Test plan

- [ ] Fresh install: `169.254.169.254` appears in Settings and `.imds-169.254.169.0` network is created
- [ ] Add a second IP: new network created, existing network and connected containers unaffected
- [ ] Remove middle IP (of 3): only that network is removed, others untouched
- [ ] Networks column shows green/grey chips per IP with correct tooltips
- [ ] All backend and UI tests pass