### PR TITLE
docs: add Alibaba and Tencent Cloud to common addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ Search for "Barnacle" in the Docker Desktop Extensions Marketplace.
 
 Any IPv4 or IPv6 address you add in Settings is intercepted. These are the well-known IMDS addresses for major providers:
 
-| Provider  | Address               | Protocol |
-|-----------|-----------------------|----------|
-| AWS / GCP | `169.254.169.254`     | IPv4     |
-| AWS       | `fd00:ec2::254`       | IPv6     |
-| OpenStack | `fd00:a9fe:a9fe::254` | IPv6     |
+| Provider       | Address               | Protocol |
+|----------------|-----------------------|----------|
+| AWS / GCP      | `169.254.169.254`     | IPv4     |
+| AWS            | `fd00:ec2::254`       | IPv6     |
+| OpenStack      | `fd00:a9fe:a9fe::254` | IPv6     |
+| Alibaba Cloud  | `100.100.100.200`     | IPv4     |
+| Tencent Cloud  | `169.254.0.23`        | IPv4     |
 
 ## How it works
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -201,7 +201,7 @@ while ($listener.IsListening) {
 
 ## Alibaba Cloud
 
-> **Note:** Alibaba Cloud IMDS uses address `100.100.100.200`, which requires a future Barnacle update to proxy. The recipe below will work once that support is added.
+Add `100.100.100.200` in Settings to intercept Alibaba Cloud IMDS traffic.
 
 Returns RAM role credentials. Reads the `ALIBABA_ROLE` label to select which RAM role to assume. Requires the `aliyun` CLI.
 
@@ -263,7 +263,7 @@ while ($listener.IsListening) {
 
 ## Tencent Cloud
 
-> **Note:** Tencent Cloud IMDS uses address `169.254.0.23`, which requires a future Barnacle update to proxy. The recipe below will work once that support is added.
+Add `169.254.0.23` in Settings to intercept Tencent Cloud IMDS traffic.
 
 Returns CAM role credentials. Reads the `TENCENT_ROLE` label to select which CAM role to use. Requires the `tccli` CLI.
 


### PR DESCRIPTION
## Summary

- Adds `100.100.100.200` (Alibaba Cloud) and `169.254.0.23` (Tencent Cloud) to the common addresses table in README
- Removes the "future Barnacle update required" caveats from recipes.md — both addresses work today via the custom IP field in Settings

## Test plan

- [ ] CI passes