### PR TITLE
refactor: collapse two container index mutexes into containerTracker struct

### DIFF
--- a/backend/benchmark_test.go
+++ b/backend/benchmark_test.go
@@ -40,9 +40,9 @@ func BenchmarkContainerTracking(b *testing.B) {
 			},
 		}
 
-		trackedContainersMutex.Lock()
-		trackedContainers[containerID] = containerInfo
-		trackedContainersMutex.Unlock()
+		tracker.mu.Lock()
+		tracker.byID[containerID] = containerInfo
+		tracker.mu.Unlock()
 
 		updateIPIndex(containerID)
 
@@ -70,9 +70,9 @@ func BenchmarkIPLookup(b *testing.B) {
 			},
 		}
 
-		trackedContainersMutex.Lock()
-		trackedContainers[containerID] = containerInfo
-		trackedContainersMutex.Unlock()
+		tracker.mu.Lock()
+		tracker.byID[containerID] = containerInfo
+		tracker.mu.Unlock()
 
 		updateIPIndex(containerID)
 	}
@@ -81,9 +81,9 @@ func BenchmarkIPLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ipAddr := fmt.Sprintf("169.254.169.%d", (i%100)%254+1)
 
-		ipToContainerIDMutex.RLock()
-		_ = ipToContainerID[ipAddr]
-		ipToContainerIDMutex.RUnlock()
+		tracker.mu.RLock()
+		_ = tracker.ipToContainerID[ipAddr]
+		tracker.mu.RUnlock()
 	}
 }
 
@@ -119,9 +119,9 @@ func BenchmarkConcurrentReads(b *testing.B) {
 			},
 		}
 
-		trackedContainersMutex.Lock()
-		trackedContainers[containerID] = containerInfo
-		trackedContainersMutex.Unlock()
+		tracker.mu.Lock()
+		tracker.byID[containerID] = containerInfo
+		tracker.mu.Unlock()
 
 		updateIPIndex(containerID)
 	}
@@ -132,9 +132,9 @@ func BenchmarkConcurrentReads(b *testing.B) {
 		for pb.Next() {
 			ipAddr := fmt.Sprintf("169.254.169.%d", (i%100)%254+1)
 
-			ipToContainerIDMutex.RLock()
-			_ = ipToContainerID[ipAddr]
-			ipToContainerIDMutex.RUnlock()
+			tracker.mu.RLock()
+			_ = tracker.ipToContainerID[ipAddr]
+			tracker.mu.RUnlock()
 
 			i++
 		}

--- a/backend/handlers_echo_test.go
+++ b/backend/handlers_echo_test.go
@@ -401,14 +401,14 @@ func TestGetContainersWithData(t *testing.T) {
 	t.Cleanup(resetTracking)
 	withDockerClient(t, &fakeDockerClient{})
 
-	trackedContainersMutex.Lock()
-	trackedContainers["abc"] = ContainerInfo{
+	tracker.mu.Lock()
+	tracker.byID["abc"] = ContainerInfo{
 		ContainerID: "abc",
 		Name:        "/test",
 		Labels:      map[string]string{},
 		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net1"}},
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	settingsMutex.Lock()
 	settings.CustomIPs = []string{"169.254.169.254"}

--- a/backend/main.go
+++ b/backend/main.go
@@ -173,17 +173,22 @@ type ContainersAPIResponse struct {
 	ProxyStatus ProxyContainerState `json:"proxyStatus"`
 }
 
+type containerTracker struct {
+	mu              sync.RWMutex
+	byID            map[string]ContainerInfo
+	ipToContainerID map[string]string
+}
+
+var tracker = &containerTracker{
+	byID:            make(map[string]ContainerInfo),
+	ipToContainerID: make(map[string]string),
+}
+
 var (
 	settings         Settings
 	settingsMutex    sync.RWMutex
 	settingsPath     = "/data/settings.json"
 	proxyComposePath = "/imds-proxy-compose.yaml"
-
-	trackedContainers      = make(map[string]ContainerInfo)
-	trackedContainersMutex sync.RWMutex
-
-	ipToContainerID      = make(map[string]string)
-	ipToContainerIDMutex sync.RWMutex
 
 	managedNetworks      []string
 	managedNetworksMutex sync.RWMutex
@@ -375,19 +380,16 @@ func getLocalIP() (string, error) {
 }
 
 func updateIPIndex(containerID string) {
-	ipToContainerIDMutex.Lock()
-	defer ipToContainerIDMutex.Unlock()
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
 
-	trackedContainersMutex.RLock()
-	defer trackedContainersMutex.RUnlock()
-
-	ctr := trackedContainers[containerID]
+	ctr := tracker.byID[containerID]
 	for _, network := range ctr.Networks {
 		if network.NetworkName != "" {
-			if ns, ok := trackedContainers[containerID]; ok {
+			if ns, ok := tracker.byID[containerID]; ok {
 				for _, net := range ns.Networks {
 					if net.NetworkName == network.NetworkName {
-						ipToContainerID[network.NetworkID] = containerID
+						tracker.ipToContainerID[network.NetworkID] = containerID
 					}
 				}
 			}
@@ -396,13 +398,13 @@ func updateIPIndex(containerID string) {
 }
 
 func removeIPIndexForContainer(containerID string, containerInfo ContainerInfo) {
-	ipToContainerIDMutex.Lock()
-	defer ipToContainerIDMutex.Unlock()
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
 
 	for _, network := range containerInfo.Networks {
 		if network.NetworkID != "" {
-			if ipToContainerID[network.NetworkID] == containerID {
-				delete(ipToContainerID, network.NetworkID)
+			if tracker.ipToContainerID[network.NetworkID] == containerID {
+				delete(tracker.ipToContainerID, network.NetworkID)
 			}
 		}
 	}
@@ -578,13 +580,13 @@ func handleContainerLookupByIP(w http.ResponseWriter, r *http.Request) {
 }
 
 func findContainerByIP(ctx context.Context, cli DockerClient, ip string) (*ProxyLookupResponse, error) {
-	trackedContainersMutex.RLock()
-	defer trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	defer tracker.mu.RUnlock()
 
-	for _, ctr := range trackedContainers {
+	for _, ctr := range tracker.byID {
 		for _, network := range ctr.Networks {
 			if network.NetworkName != "" {
-				ns, ok := trackedContainers[ctr.ContainerID]
+				ns, ok := tracker.byID[ctr.ContainerID]
 				if ok {
 					for _, net := range ns.Networks {
 						if net.NetworkName != "" {
@@ -697,9 +699,9 @@ func monitorDockerEvents() {
 				case "connect", "disconnect":
 					containerID := event.Actor.Attributes["container"]
 					if containerID != "" {
-						trackedContainersMutex.RLock()
-						_, tracked := trackedContainers[containerID]
-						trackedContainersMutex.RUnlock()
+						tracker.mu.RLock()
+						_, tracked := tracker.byID[containerID]
+						tracker.mu.RUnlock()
 						if tracked {
 							if err := refreshContainerNetworks(ctx, dockerClient, containerID); err != nil {
 								logger.Errorf("Failed to refresh networks for container %s: %v", shortID(containerID), err)
@@ -732,7 +734,7 @@ func scanExistingContainers(ctx context.Context, cli DockerClient) error {
 		}
 	}
 
-	logger.Infof("Scanned existing containers, found %d with imds-proxy.enabled=true", len(trackedContainers))
+	logger.Infof("Scanned existing containers, found %d with imds-proxy.enabled=true", len(tracker.byID))
 	return nil
 }
 
@@ -815,9 +817,9 @@ func addContainerToTrackingWithNetwork(ctx context.Context, cli DockerClient, co
 		containerInfo.Labels = make(map[string]string)
 	}
 
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = containerInfo
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[containerID] = containerInfo
+	tracker.mu.Unlock()
 
 	updateIPIndex(containerID)
 
@@ -826,12 +828,12 @@ func addContainerToTrackingWithNetwork(ctx context.Context, cli DockerClient, co
 }
 
 func removeContainerFromTracking(containerID string) {
-	trackedContainersMutex.Lock()
-	info, exists := trackedContainers[containerID]
+	tracker.mu.Lock()
+	info, exists := tracker.byID[containerID]
 	if exists {
-		delete(trackedContainers, containerID)
+		delete(tracker.byID, containerID)
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	if exists {
 		removeIPIndexForContainer(containerID, info)
@@ -853,13 +855,13 @@ func refreshContainerNetworks(ctx context.Context, cli DockerClient, containerID
 		})
 	}
 
-	trackedContainersMutex.Lock()
-	info, exists := trackedContainers[containerID]
+	tracker.mu.Lock()
+	info, exists := tracker.byID[containerID]
 	if exists {
 		info.Networks = networks
-		trackedContainers[containerID] = info
+		tracker.byID[containerID] = info
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	if exists {
 		updateIPIndex(containerID)
@@ -1034,12 +1036,12 @@ func reconcileNetworks(ctx context.Context, cli DockerClient, desired []NetworkC
 	}
 
 	// 5. Reconnect tracked containers to the new networks
-	trackedContainersMutex.RLock()
-	containerIDs := make([]string, 0, len(trackedContainers))
-	for id := range trackedContainers {
+	tracker.mu.RLock()
+	containerIDs := make([]string, 0, len(tracker.byID))
+	for id := range tracker.byID {
 		containerIDs = append(containerIDs, id)
 	}
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RUnlock()
 
 	for _, cid := range containerIDs {
 		for _, d := range desired {
@@ -1102,16 +1104,16 @@ func disconnectAllFromNetwork(ctx context.Context, cli DockerClient, networkName
 }
 
 func getContainers(ctx echo.Context) error {
-	trackedContainersMutex.RLock()
-	defer trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	defer tracker.mu.RUnlock()
 
 	settingsMutex.RLock()
 	netConfig := settings.NetworkConfig
 	customIPs := settings.CustomIPs
 	settingsMutex.RUnlock()
 
-	containerList := make([]ContainerInfo, 0, len(trackedContainers))
-	for _, info := range trackedContainers {
+	containerList := make([]ContainerInfo, 0, len(tracker.byID))
+	for _, info := range tracker.byID {
 		info.Addresses = buildAddressStatuses(info.Networks, netConfig, customIPs)
 		containerList = append(containerList, info)
 	}

--- a/backend/monitor_test.go
+++ b/backend/monitor_test.go
@@ -163,9 +163,9 @@ func TestMonitorDockerEventsContainerCreate(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	trackedContainersMutex.RLock()
-	_, tracked := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	_, tracked := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 	if !tracked {
 		t.Errorf("want container %s tracked after create event", containerID)
 	}
@@ -192,9 +192,9 @@ func TestMonitorDockerEventsContainerCreateNoLabel(t *testing.T) {
 	}
 	time.Sleep(50 * time.Millisecond)
 
-	trackedContainersMutex.RLock()
-	_, tracked := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	_, tracked := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 	if tracked {
 		t.Errorf("want unlabeled container %s NOT tracked", containerID)
 	}
@@ -205,9 +205,9 @@ func TestMonitorDockerEventsContainerDestroy(t *testing.T) {
 	t.Cleanup(resetTracking)
 
 	containerID := "monitor-destroy-abc"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{ContainerID: containerID, Name: "/to-destroy"}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{ContainerID: containerID, Name: "/to-destroy"}
+	tracker.mu.Unlock()
 
 	cli := newMonitorDockerClient()
 	withDockerClient(t, cli)
@@ -222,9 +222,9 @@ func TestMonitorDockerEventsContainerDestroy(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	trackedContainersMutex.RLock()
-	_, tracked := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	_, tracked := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 	if tracked {
 		t.Errorf("want container %s removed after destroy event", containerID)
 	}
@@ -235,9 +235,9 @@ func TestMonitorDockerEventsNetworkConnect(t *testing.T) {
 	t.Cleanup(resetTracking)
 
 	containerID := "monitor-net-abc"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{ContainerID: containerID, Name: "/net-test", Networks: []NetworkInfo{}}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{ContainerID: containerID, Name: "/net-test", Networks: []NetworkInfo{}}
+	tracker.mu.Unlock()
 
 	cli := newMonitorDockerClient()
 	cli.fakeDockerClient.inspectSequence = []container.InspectResponse{

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -120,16 +120,11 @@ func (f *fakeDockerClient) Close() error {
 }
 
 func resetTracking() {
-	// Acquire locks in consistent order: ipToContainerIDMutex -> trackedContainersMutex
-	// This matches the order in updateIPIndex() and prevents deadlocks
-	ipToContainerIDMutex.Lock()
-	defer ipToContainerIDMutex.Unlock()
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
 
-	trackedContainersMutex.Lock()
-	defer trackedContainersMutex.Unlock()
-
-	ipToContainerID = make(map[string]string)
-	trackedContainers = make(map[string]ContainerInfo)
+	tracker.ipToContainerID = make(map[string]string)
+	tracker.byID = make(map[string]ContainerInfo)
 }
 
 func TestUpdateAndRemoveIPIndex(t *testing.T) {
@@ -137,33 +132,33 @@ func TestUpdateAndRemoveIPIndex(t *testing.T) {
 	defer resetTracking()
 
 	containerID := "abc123"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{
 		ContainerID: containerID,
 		Networks: []NetworkInfo{{
 			NetworkID:   "net-1",
 			NetworkName: "imds",
 		}},
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	updateIPIndex(containerID)
 
-	ipToContainerIDMutex.RLock()
-	if got := ipToContainerID["net-1"]; got != containerID {
-		ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	if got := tracker.ipToContainerID["net-1"]; got != containerID {
+		tracker.mu.RUnlock()
 		t.Fatalf("want ip index to be set, got %q", got)
 	}
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RUnlock()
 
-	removeIPIndexForContainer(containerID, trackedContainers[containerID])
+	removeIPIndexForContainer(containerID, tracker.byID[containerID])
 
-	ipToContainerIDMutex.RLock()
-	if _, ok := ipToContainerID["net-1"]; ok {
-		ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	if _, ok := tracker.ipToContainerID["net-1"]; ok {
+		tracker.mu.RUnlock()
 		t.Fatalf("want ip index to be cleared")
 	}
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RUnlock()
 }
 
 func TestAddAndRemoveContainerTracking(t *testing.T) {
@@ -224,9 +219,9 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 		t.Fatalf("want two network connect calls, got %d", len(client.networkConnectCalls))
 	}
 
-	trackedContainersMutex.RLock()
-	info, ok := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	info, ok := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 	if !ok {
 		t.Fatalf("want container to be tracked")
 	}
@@ -237,25 +232,25 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 		t.Fatalf("want labels to be initialized")
 	}
 
-	ipToContainerIDMutex.RLock()
-	if got := ipToContainerID["net-aws"]; got != containerID {
-		ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	if got := tracker.ipToContainerID["net-aws"]; got != containerID {
+		tracker.mu.RUnlock()
 		t.Fatalf("want net-aws mapping, got %q", got)
 	}
-	if got := ipToContainerID["net-os"]; got != containerID {
-		ipToContainerIDMutex.RUnlock()
+	if got := tracker.ipToContainerID["net-os"]; got != containerID {
+		tracker.mu.RUnlock()
 		t.Fatalf("want net-os mapping, got %q", got)
 	}
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RUnlock()
 
 	removeContainerFromTracking(containerID)
 
-	trackedContainersMutex.RLock()
-	if _, ok := trackedContainers[containerID]; ok {
-		trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	if _, ok := tracker.byID[containerID]; ok {
+		tracker.mu.RUnlock()
 		t.Fatalf("want container to be removed")
 	}
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RUnlock()
 }
 
 func TestAddContainerToTrackingWithNetworkPauseFirst(t *testing.T) {
@@ -343,17 +338,17 @@ func TestConcurrentContainerTracking(t *testing.T) {
 					},
 				}
 
-				trackedContainersMutex.Lock()
-				trackedContainers[containerID] = containerInfo
-				trackedContainersMutex.Unlock()
+				tracker.mu.Lock()
+				tracker.byID[containerID] = containerInfo
+				tracker.mu.Unlock()
 
 				// Update IP index
 				updateIPIndex(containerID)
 
 				// Lookup by IP
-				ipToContainerIDMutex.RLock()
-				got := ipToContainerID[ipAddr]
-				ipToContainerIDMutex.RUnlock()
+				tracker.mu.RLock()
+				got := tracker.ipToContainerID[ipAddr]
+				tracker.mu.RUnlock()
 				if got != containerID {
 					t.Errorf("want IP mapping %s=%s, got %s", ipAddr, containerID, got)
 				}
@@ -367,9 +362,9 @@ func TestConcurrentContainerTracking(t *testing.T) {
 	wg.Wait()
 
 	// Verify clean state
-	trackedContainersMutex.RLock()
-	numTracked := len(trackedContainers)
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	numTracked := len(tracker.byID)
+	tracker.mu.RUnlock()
 
 	if numTracked != 0 {
 		t.Errorf("want 0 tracked containers after cleanup, got %d", numTracked)
@@ -396,9 +391,9 @@ func TestConcurrentIPLookup(t *testing.T) {
 			},
 		}
 
-		trackedContainersMutex.Lock()
-		trackedContainers[containerID] = containerInfo
-		trackedContainersMutex.Unlock()
+		tracker.mu.Lock()
+		tracker.byID[containerID] = containerInfo
+		tracker.mu.Unlock()
 
 		updateIPIndex(containerID)
 	}
@@ -417,9 +412,9 @@ func TestConcurrentIPLookup(t *testing.T) {
 				ipAddr := fmt.Sprintf("169.254.169.%d", j%100%254+1)
 				expectedID := containers[ipAddr]
 
-				ipToContainerIDMutex.RLock()
-				got := ipToContainerID[ipAddr]
-				ipToContainerIDMutex.RUnlock()
+				tracker.mu.RLock()
+				got := tracker.ipToContainerID[ipAddr]
+				tracker.mu.RUnlock()
 
 				if got != expectedID {
 					t.Errorf("want IP mapping %s=%s, got %s", ipAddr, expectedID, got)
@@ -498,9 +493,9 @@ func TestRaceConditionInDockerEventProcessing(t *testing.T) {
 				},
 			}
 
-			trackedContainersMutex.Lock()
-			trackedContainers[containerID] = containerInfo
-			trackedContainersMutex.Unlock()
+			tracker.mu.Lock()
+			tracker.byID[containerID] = containerInfo
+			tracker.mu.Unlock()
 
 			// Simulate network connect
 			updateIPIndex(containerID)
@@ -513,13 +508,13 @@ func TestRaceConditionInDockerEventProcessing(t *testing.T) {
 	wg.Wait()
 
 	// Verify clean state
-	trackedContainersMutex.RLock()
-	numTracked := len(trackedContainers)
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	numTracked := len(tracker.byID)
+	tracker.mu.RUnlock()
 
-	ipToContainerIDMutex.RLock()
-	numIPs := len(ipToContainerID)
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	numIPs := len(tracker.ipToContainerID)
+	tracker.mu.RUnlock()
 
 	if numTracked != 0 {
 		t.Errorf("want 0 tracked containers, got %d", numTracked)
@@ -542,16 +537,16 @@ func TestEdgeCaseEmptyContainerID(t *testing.T) {
 		},
 	}
 
-	trackedContainersMutex.Lock()
-	trackedContainers[""] = containerInfo
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[""] = containerInfo
+	tracker.mu.Unlock()
 
 	updateIPIndex("")
 
 	// Should handle empty ID gracefully
-	ipToContainerIDMutex.RLock()
-	got := ipToContainerID["169.254.169.100"]
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	got := tracker.ipToContainerID["169.254.169.100"]
+	tracker.mu.RUnlock()
 
 	if got != "" {
 		t.Errorf("want empty string mapping, got %q", got)
@@ -559,9 +554,9 @@ func TestEdgeCaseEmptyContainerID(t *testing.T) {
 
 	removeContainerFromTracking("")
 
-	trackedContainersMutex.RLock()
-	_, exists := trackedContainers[""]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	_, exists := tracker.byID[""]
+	tracker.mu.RUnlock()
 
 	if exists {
 		t.Error("empty container ID should be removable")
@@ -597,16 +592,16 @@ func TestEdgeCaseUnicodeContainerName(t *testing.T) {
 				},
 			}
 
-			trackedContainersMutex.Lock()
-			trackedContainers[containerID] = containerInfo
-			trackedContainersMutex.Unlock()
+			tracker.mu.Lock()
+			tracker.byID[containerID] = containerInfo
+			tracker.mu.Unlock()
 
 			updateIPIndex(containerID)
 
 			// Verify container is tracked
-			trackedContainersMutex.RLock()
-			stored, exists := trackedContainers[containerID]
-			trackedContainersMutex.RUnlock()
+			tracker.mu.RLock()
+			stored, exists := tracker.byID[containerID]
+			tracker.mu.RUnlock()
 
 			if !exists {
 				t.Fatalf("container %q should be tracked", containerID)
@@ -616,9 +611,9 @@ func TestEdgeCaseUnicodeContainerName(t *testing.T) {
 			}
 
 			// Verify IP mapping
-			ipToContainerIDMutex.RLock()
-			got := ipToContainerID[ipAddr]
-			ipToContainerIDMutex.RUnlock()
+			tracker.mu.RLock()
+			got := tracker.ipToContainerID[ipAddr]
+			tracker.mu.RUnlock()
 
 			if got != containerID {
 				t.Errorf("want IP mapping to %q, got %q", containerID, got)
@@ -646,16 +641,16 @@ func TestEdgeCaseVeryLongContainerID(t *testing.T) {
 		},
 	}
 
-	trackedContainersMutex.Lock()
-	trackedContainers[longID] = containerInfo
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[longID] = containerInfo
+	tracker.mu.Unlock()
 
 	updateIPIndex(longID)
 
 	// Verify storage works with long IDs
-	trackedContainersMutex.RLock()
-	stored, exists := trackedContainers[longID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	stored, exists := tracker.byID[longID]
+	tracker.mu.RUnlock()
 
 	if !exists {
 		t.Fatal("long container ID should be tracked")
@@ -665,9 +660,9 @@ func TestEdgeCaseVeryLongContainerID(t *testing.T) {
 	}
 
 	// Verify IP mapping
-	ipToContainerIDMutex.RLock()
-	got := ipToContainerID[ipAddr]
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	got := tracker.ipToContainerID[ipAddr]
+	tracker.mu.RUnlock()
 
 	if got != longID {
 		t.Errorf("want IP mapping to long ID, got %q", got)
@@ -694,16 +689,16 @@ func TestEdgeCaseVeryLongContainerName(t *testing.T) {
 		},
 	}
 
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = containerInfo
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[containerID] = containerInfo
+	tracker.mu.Unlock()
 
 	updateIPIndex(containerID)
 
 	// Verify storage works with long names
-	trackedContainersMutex.RLock()
-	stored, exists := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	stored, exists := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 
 	if !exists {
 		t.Fatal("container with long name should be tracked")
@@ -730,17 +725,17 @@ func TestEdgeCaseEmptyNetworkID(t *testing.T) {
 		},
 	}
 
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = containerInfo
-	trackedContainersMutex.Unlock()
+	tracker.mu.Lock()
+	tracker.byID[containerID] = containerInfo
+	tracker.mu.Unlock()
 
 	updateIPIndex(containerID)
 
 	// Current behavior: creates mapping with empty key (edge case that doesn't crash)
 	// This documents existing behavior rather than enforcing validation
-	ipToContainerIDMutex.RLock()
-	_, exists := ipToContainerID[""]
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	_, exists := tracker.ipToContainerID[""]
+	tracker.mu.RUnlock()
 
 	// System handles empty NetworkID without panic
 	if os.Getenv("VERBOSE_TESTS") != "" {
@@ -817,21 +812,21 @@ func TestStressHighConcurrentContainerOperations(t *testing.T) {
 				}
 
 				// Add container
-				trackedContainersMutex.Lock()
-				trackedContainers[containerID] = containerInfo
-				trackedContainersMutex.Unlock()
+				tracker.mu.Lock()
+				tracker.byID[containerID] = containerInfo
+				tracker.mu.Unlock()
 
 				// Update IP index
 				updateIPIndex(containerID)
 
 				// Read operations
-				ipToContainerIDMutex.RLock()
-				_ = ipToContainerID[ipAddr]
-				ipToContainerIDMutex.RUnlock()
+				tracker.mu.RLock()
+				_ = tracker.ipToContainerID[ipAddr]
+				tracker.mu.RUnlock()
 
-				trackedContainersMutex.RLock()
-				_ = trackedContainers[containerID]
-				trackedContainersMutex.RUnlock()
+				tracker.mu.RLock()
+				_ = tracker.byID[containerID]
+				tracker.mu.RUnlock()
 
 				// Delete container
 				if j%10 == 0 {
@@ -844,13 +839,13 @@ func TestStressHighConcurrentContainerOperations(t *testing.T) {
 	wg.Wait()
 
 	// Verify system is in consistent state
-	trackedContainersMutex.RLock()
-	numTracked := len(trackedContainers)
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	numTracked := len(tracker.byID)
+	tracker.mu.RUnlock()
 
-	ipToContainerIDMutex.RLock()
-	numIPs := len(ipToContainerID)
-	ipToContainerIDMutex.RUnlock()
+	tracker.mu.RLock()
+	numIPs := len(tracker.ipToContainerID)
+	tracker.mu.RUnlock()
 
 	t.Logf("After stress test: %d tracked containers, %d IP mappings", numTracked, numIPs)
 
@@ -890,14 +885,14 @@ func TestStressMutexContention(t *testing.T) {
 					return
 				default:
 					// Read from tracked containers
-					trackedContainersMutex.RLock()
-					_ = len(trackedContainers)
-					trackedContainersMutex.RUnlock()
+					tracker.mu.RLock()
+					_ = len(tracker.byID)
+					tracker.mu.RUnlock()
 
 					// Read from IP index
-					ipToContainerIDMutex.RLock()
-					_ = len(ipToContainerID)
-					ipToContainerIDMutex.RUnlock()
+					tracker.mu.RLock()
+					_ = len(tracker.ipToContainerID)
+					tracker.mu.RUnlock()
 
 					readCount++
 				}
@@ -930,9 +925,9 @@ func TestStressMutexContention(t *testing.T) {
 						},
 					}
 
-					trackedContainersMutex.Lock()
-					trackedContainers[containerID] = containerInfo
-					trackedContainersMutex.Unlock()
+					tracker.mu.Lock()
+					tracker.byID[containerID] = containerInfo
+					tracker.mu.Unlock()
 
 					updateIPIndex(containerID)
 
@@ -954,9 +949,9 @@ func TestStressMutexContention(t *testing.T) {
 	wg.Wait()
 
 	// Verify no corruption
-	trackedContainersMutex.RLock()
-	numTracked := len(trackedContainers)
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	numTracked := len(tracker.byID)
+	tracker.mu.RUnlock()
 
 	t.Logf("After contention test: %d containers remain tracked", numTracked)
 }
@@ -1030,9 +1025,9 @@ func TestScanExistingContainersEmpty(t *testing.T) {
 		t.Fatalf("want no error, got %v", err)
 	}
 
-	trackedContainersMutex.RLock()
-	n := len(trackedContainers)
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	n := len(tracker.byID)
+	tracker.mu.RUnlock()
 	if n != 0 {
 		t.Errorf("want 0 tracked containers, got %d", n)
 	}
@@ -1085,9 +1080,9 @@ func TestScanExistingContainersLabeledContainer(t *testing.T) {
 		t.Fatalf("want no error, got %v", err)
 	}
 
-	trackedContainersMutex.RLock()
-	_, ok := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	_, ok := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 	if !ok {
 		t.Errorf("want container %s to be tracked", containerID)
 	}
@@ -1110,9 +1105,9 @@ func TestScanExistingContainersUnlabeledContainer(t *testing.T) {
 		t.Fatalf("want no error, got %v", err)
 	}
 
-	trackedContainersMutex.RLock()
-	n := len(trackedContainers)
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	n := len(tracker.byID)
+	tracker.mu.RUnlock()
 	if n != 0 {
 		t.Errorf("want 0 tracked containers for unlabeled container, got %d", n)
 	}
@@ -1200,14 +1195,14 @@ func TestRefreshContainerNetworksTracked(t *testing.T) {
 	t.Cleanup(resetTracking)
 
 	containerID := "refresh123"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{
 		ContainerID: containerID,
 		Name:        "/refresh-test",
 		Labels:      map[string]string{},
 		Networks:    []NetworkInfo{},
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	cli := &fakeDockerClient{
 		inspectSequence: []container.InspectResponse{
@@ -1231,9 +1226,9 @@ func TestRefreshContainerNetworksTracked(t *testing.T) {
 		t.Fatalf("want no error, got %v", err)
 	}
 
-	trackedContainersMutex.RLock()
-	info := trackedContainers[containerID]
-	trackedContainersMutex.RUnlock()
+	tracker.mu.RLock()
+	info := tracker.byID[containerID]
+	tracker.mu.RUnlock()
 
 	if len(info.Networks) != 1 {
 		t.Fatalf("want 1 network after refresh, got %d", len(info.Networks))
@@ -1263,7 +1258,7 @@ func TestRefreshContainerNetworksUntracked(t *testing.T) {
 		},
 	}
 
-	// Container is not in trackedContainers - should return nil without panic.
+	// Container is not in tracker.byID - should return nil without panic.
 	if err := refreshContainerNetworks(context.Background(), cli, "untracked999"); err != nil {
 		t.Fatalf("want no error for untracked container, got %v", err)
 	}
@@ -1286,14 +1281,14 @@ func TestFindContainerByIPFound(t *testing.T) {
 	t.Cleanup(resetTracking)
 
 	containerID := "ipfound123"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{
 		ContainerID: containerID,
 		Name:        "/ip-test",
 		Labels:      map[string]string{"app": "test"},
 		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-x"}},
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	cli := &fakeDockerClient{
 		inspectSequence: []container.InspectResponse{
@@ -1330,14 +1325,14 @@ func TestFindContainerByIPNotFound(t *testing.T) {
 	t.Cleanup(resetTracking)
 
 	containerID := "ipnotfound456"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{
 		ContainerID: containerID,
 		Name:        "/no-ip",
 		Labels:      map[string]string{},
 		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-y"}},
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	cli := &fakeDockerClient{
 		inspectSequence: []container.InspectResponse{
@@ -1371,14 +1366,14 @@ func TestFindContainerByIPInspectError(t *testing.T) {
 	t.Cleanup(resetTracking)
 
 	containerID := "inspect-err-789"
-	trackedContainersMutex.Lock()
-	trackedContainers[containerID] = ContainerInfo{
+	tracker.mu.Lock()
+	tracker.byID[containerID] = ContainerInfo{
 		ContainerID: containerID,
 		Name:        "/err-container",
 		Labels:      map[string]string{},
 		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-z"}},
 	}
-	trackedContainersMutex.Unlock()
+	tracker.mu.Unlock()
 
 	cli := &fakeDockerClient{inspectErr: errors.New("inspect error")}
 


### PR DESCRIPTION
## Summary

- `trackedContainers`/`trackedContainersMutex` and `ipToContainerID`/`ipToContainerIDMutex` were logically one index protected by two separate mutexes
- The cross-mutex acquisition in `updateIPIndex` required careful lock ordering to avoid deadlocks
- Replaced with a single `containerTracker` struct holding both maps under one `sync.RWMutex`, eliminating the ordering constraint entirely

## Test plan

- [ ] CI passes