### PR TITLE
perf: O(1) container IP lookup via reverse IP index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node-compile-cache/
 docker-desktop-imds-proxy
 docker-desktop-imds-proxy-proxy
 TODO.md
+.claude/

--- a/backend/handlers_test.go
+++ b/backend/handlers_test.go
@@ -16,14 +16,13 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
-func withFindContainerByIP(t *testing.T, fn func(context.Context, DockerClient, string) (*ProxyLookupResponse, error)) {
+func withFindContainerByIP(t *testing.T, fn func(string) (*ProxyLookupResponse, error)) {
 	original := findContainerByIPFn
 	findContainerByIPFn = fn
 	t.Cleanup(func() { findContainerByIPFn = original })
@@ -74,7 +73,7 @@ func TestHandleContainerLookupByIPEmptyIP(t *testing.T) {
 }
 
 func TestHandleContainerLookupByIPNotFound(t *testing.T) {
-	withFindContainerByIP(t, func(ctx context.Context, _ DockerClient, _ string) (*ProxyLookupResponse, error) {
+	withFindContainerByIP(t, func(_ string) (*ProxyLookupResponse, error) {
 		return nil, nil
 	})
 
@@ -89,7 +88,7 @@ func TestHandleContainerLookupByIPNotFound(t *testing.T) {
 }
 
 func TestHandleContainerLookupByIPError(t *testing.T) {
-	withFindContainerByIP(t, func(ctx context.Context, _ DockerClient, _ string) (*ProxyLookupResponse, error) {
+	withFindContainerByIP(t, func(_ string) (*ProxyLookupResponse, error) {
 		return nil, errors.New("boom")
 	})
 
@@ -104,7 +103,7 @@ func TestHandleContainerLookupByIPError(t *testing.T) {
 }
 
 func TestHandleContainerLookupByIPSuccess(t *testing.T) {
-	withFindContainerByIP(t, func(ctx context.Context, _ DockerClient, ip string) (*ProxyLookupResponse, error) {
+	withFindContainerByIP(t, func(ip string) (*ProxyLookupResponse, error) {
 		return &ProxyLookupResponse{
 			ContainerID: "abc123",
 			Name:        "/my-container",

--- a/backend/main.go
+++ b/backend/main.go
@@ -151,6 +151,8 @@ type ProxyLookupResponse struct {
 type NetworkInfo struct {
 	NetworkID   string `json:"networkId"`
 	NetworkName string `json:"networkName"`
+	IPAddress   string `json:"ipAddress,omitempty"`
+	IPv6Address string `json:"ipv6Address,omitempty"`
 }
 
 // AddressStatus is the per-container API representation of a single configured
@@ -197,7 +199,7 @@ var (
 	shutdownChan = make(chan struct{})
 )
 
-var findContainerByIPFn = findContainerByIP
+var findContainerByIPFn func(ip string) (*ProxyLookupResponse, error) = findContainerByIP
 
 // notifyProxyConfigUpdateFn is a variable so tests can replace it with a no-op
 // to avoid spawning background goroutines that race with test cleanup.
@@ -384,15 +386,12 @@ func updateIPIndex(containerID string) {
 	defer tracker.mu.Unlock()
 
 	ctr := tracker.byID[containerID]
-	for _, network := range ctr.Networks {
-		if network.NetworkName != "" {
-			if ns, ok := tracker.byID[containerID]; ok {
-				for _, net := range ns.Networks {
-					if net.NetworkName == network.NetworkName {
-						tracker.ipToContainerID[network.NetworkID] = containerID
-					}
-				}
-			}
+	for _, net := range ctr.Networks {
+		if net.IPAddress != "" {
+			tracker.ipToContainerID[net.IPAddress] = containerID
+		}
+		if net.IPv6Address != "" {
+			tracker.ipToContainerID[net.IPv6Address] = containerID
 		}
 	}
 }
@@ -401,11 +400,12 @@ func removeIPIndexForContainer(containerID string, containerInfo ContainerInfo) 
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 
-	for _, network := range containerInfo.Networks {
-		if network.NetworkID != "" {
-			if tracker.ipToContainerID[network.NetworkID] == containerID {
-				delete(tracker.ipToContainerID, network.NetworkID)
-			}
+	for _, net := range containerInfo.Networks {
+		if net.IPAddress != "" && tracker.ipToContainerID[net.IPAddress] == containerID {
+			delete(tracker.ipToContainerID, net.IPAddress)
+		}
+		if net.IPv6Address != "" && tracker.ipToContainerID[net.IPv6Address] == containerID {
+			delete(tracker.ipToContainerID, net.IPv6Address)
 		}
 	}
 }
@@ -554,10 +554,7 @@ func handleContainerLookupByIP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-	defer cancel()
-
-	response, err := findContainerByIPFn(ctx, dockerClient, request.IP)
+	response, err := findContainerByIPFn(request.IP)
 	if err != nil {
 		logger.Errorf("Failed to lookup container for IP %s: %v", request.IP, err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -579,43 +576,23 @@ func handleContainerLookupByIP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func findContainerByIP(ctx context.Context, cli DockerClient, ip string) (*ProxyLookupResponse, error) {
+func findContainerByIP(ip string) (*ProxyLookupResponse, error) {
 	tracker.mu.RLock()
 	defer tracker.mu.RUnlock()
 
-	for _, ctr := range tracker.byID {
-		for _, network := range ctr.Networks {
-			if network.NetworkName != "" {
-				ns, ok := tracker.byID[ctr.ContainerID]
-				if ok {
-					for _, net := range ns.Networks {
-						if net.NetworkName != "" {
-							inspect, err := cli.ContainerInspect(ctx, ctr.ContainerID)
-							if err != nil {
-								continue
-							}
-
-							if inspect.NetworkSettings == nil {
-								continue
-							}
-
-							if settings, ok := inspect.NetworkSettings.Networks[net.NetworkName]; ok {
-								if settings.IPAddress == ip || settings.GlobalIPv6Address == ip {
-									return &ProxyLookupResponse{
-										ContainerID: ctr.ContainerID,
-										Name:        ctr.Name,
-										Labels:      ctr.Labels,
-									}, nil
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+	containerID, ok := tracker.ipToContainerID[ip]
+	if !ok {
+		return nil, nil
 	}
-
-	return nil, nil
+	ctr, ok := tracker.byID[containerID]
+	if !ok {
+		return nil, nil
+	}
+	return &ProxyLookupResponse{
+		ContainerID: ctr.ContainerID,
+		Name:        ctr.Name,
+		Labels:      ctr.Labels,
+	}, nil
 }
 
 func persistSettings() error {
@@ -803,6 +780,8 @@ func addContainerToTrackingWithNetwork(ctx context.Context, cli DockerClient, co
 		networks = append(networks, NetworkInfo{
 			NetworkID:   networkSettings.NetworkID,
 			NetworkName: networkName,
+			IPAddress:   networkSettings.IPAddress,
+			IPv6Address: networkSettings.GlobalIPv6Address,
 		})
 	}
 
@@ -852,6 +831,8 @@ func refreshContainerNetworks(ctx context.Context, cli DockerClient, containerID
 		networks = append(networks, NetworkInfo{
 			NetworkID:   networkSettings.NetworkID,
 			NetworkName: networkName,
+			IPAddress:   networkSettings.IPAddress,
+			IPv6Address: networkSettings.GlobalIPv6Address,
 		})
 	}
 

--- a/backend/monitor_test.go
+++ b/backend/monitor_test.go
@@ -330,7 +330,7 @@ func TestStartProxySocketServer(t *testing.T) {
 
 	withSettings(t, Settings{URL: "http://proxy-server-test.example.com"})
 	withDockerClient(t, &fakeDockerClient{})
-	withFindContainerByIP(t, func(_ context.Context, _ DockerClient, _ string) (*ProxyLookupResponse, error) {
+	withFindContainerByIP(t, func(_ string) (*ProxyLookupResponse, error) {
 		return nil, nil
 	})
 

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -138,6 +138,7 @@ func TestUpdateAndRemoveIPIndex(t *testing.T) {
 		Networks: []NetworkInfo{{
 			NetworkID:   "net-1",
 			NetworkName: "imds",
+			IPAddress:   "10.0.0.1",
 		}},
 	}
 	tracker.mu.Unlock()
@@ -145,7 +146,7 @@ func TestUpdateAndRemoveIPIndex(t *testing.T) {
 	updateIPIndex(containerID)
 
 	tracker.mu.RLock()
-	if got := tracker.ipToContainerID["net-1"]; got != containerID {
+	if got := tracker.ipToContainerID["10.0.0.1"]; got != containerID {
 		tracker.mu.RUnlock()
 		t.Fatalf("want ip index to be set, got %q", got)
 	}
@@ -154,7 +155,7 @@ func TestUpdateAndRemoveIPIndex(t *testing.T) {
 	removeIPIndexForContainer(containerID, tracker.byID[containerID])
 
 	tracker.mu.RLock()
-	if _, ok := tracker.ipToContainerID["net-1"]; ok {
+	if _, ok := tracker.ipToContainerID["10.0.0.1"]; ok {
 		tracker.mu.RUnlock()
 		t.Fatalf("want ip index to be cleared")
 	}
@@ -201,9 +202,11 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 			Networks: map[string]*network.EndpointSettings{
 				".imds-0": {
 					NetworkID: "net-aws",
+					IPAddress: "172.20.0.2",
 				},
 				".imds-1": {
 					NetworkID: "net-os",
+					IPAddress: "172.21.0.2",
 				},
 			},
 		},
@@ -233,13 +236,13 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 	}
 
 	tracker.mu.RLock()
-	if got := tracker.ipToContainerID["net-aws"]; got != containerID {
+	if got := tracker.ipToContainerID["172.20.0.2"]; got != containerID {
 		tracker.mu.RUnlock()
-		t.Fatalf("want net-aws mapping, got %q", got)
+		t.Fatalf("want 172.20.0.2 mapping, got %q", got)
 	}
-	if got := tracker.ipToContainerID["net-os"]; got != containerID {
+	if got := tracker.ipToContainerID["172.21.0.2"]; got != containerID {
 		tracker.mu.RUnlock()
-		t.Fatalf("want net-os mapping, got %q", got)
+		t.Fatalf("want 172.21.0.2 mapping, got %q", got)
 	}
 	tracker.mu.RUnlock()
 
@@ -334,7 +337,7 @@ func TestConcurrentContainerTracking(t *testing.T) {
 					ContainerID: containerID,
 					Name:        fmt.Sprintf("/test-%d-%d", id, j),
 					Networks: []NetworkInfo{
-						{NetworkID: ipAddr, NetworkName: fmt.Sprintf("net-%d", j)},
+						{NetworkID: ipAddr, NetworkName: fmt.Sprintf("net-%d", j), IPAddress: ipAddr},
 					},
 				}
 
@@ -387,7 +390,7 @@ func TestConcurrentIPLookup(t *testing.T) {
 			ContainerID: containerID,
 			Name:        fmt.Sprintf("/test-%d", i),
 			Networks: []NetworkInfo{
-				{NetworkID: ipAddr, NetworkName: fmt.Sprintf("net-%d", i)},
+				{NetworkID: ipAddr, NetworkName: fmt.Sprintf("net-%d", i), IPAddress: ipAddr},
 			},
 		}
 
@@ -588,7 +591,7 @@ func TestEdgeCaseUnicodeContainerName(t *testing.T) {
 				ContainerID: containerID,
 				Name:        tc.containerName,
 				Networks: []NetworkInfo{
-					{NetworkID: ipAddr, NetworkName: "bridge"},
+					{NetworkID: ipAddr, NetworkName: "bridge", IPAddress: ipAddr},
 				},
 			}
 
@@ -637,7 +640,7 @@ func TestEdgeCaseVeryLongContainerID(t *testing.T) {
 		ContainerID: longID,
 		Name:        "/test-long-id",
 		Networks: []NetworkInfo{
-			{NetworkID: ipAddr, NetworkName: "bridge"},
+			{NetworkID: ipAddr, NetworkName: "bridge", IPAddress: ipAddr},
 		},
 	}
 
@@ -1286,29 +1289,12 @@ func TestFindContainerByIPFound(t *testing.T) {
 		ContainerID: containerID,
 		Name:        "/ip-test",
 		Labels:      map[string]string{"app": "test"},
-		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-x"}},
+		Networks:    []NetworkInfo{{NetworkName: ".imds-169.254.169.0", NetworkID: "net-x", IPAddress: "10.5.0.42"}},
 	}
+	tracker.ipToContainerID["10.5.0.42"] = containerID
 	tracker.mu.Unlock()
 
-	cli := &fakeDockerClient{
-		inspectSequence: []container.InspectResponse{
-			{
-				ContainerJSONBase: &container.ContainerJSONBase{
-					ID:    containerID,
-					Name:  "/ip-test",
-					State: &container.State{Running: true},
-				},
-				Config: &container.Config{Labels: map[string]string{"app": "test"}},
-				NetworkSettings: &container.NetworkSettings{
-					Networks: map[string]*network.EndpointSettings{
-						".imds-0": {NetworkID: "net-x", IPAddress: "10.5.0.42"},
-					},
-				},
-			},
-		},
-	}
-
-	resp, err := findContainerByIP(context.Background(), cli, "10.5.0.42")
+	resp, err := findContainerByIP("10.5.0.42")
 	if err != nil {
 		t.Fatalf("want no error, got %v", err)
 	}
@@ -1324,35 +1310,7 @@ func TestFindContainerByIPNotFound(t *testing.T) {
 	resetTracking()
 	t.Cleanup(resetTracking)
 
-	containerID := "ipnotfound456"
-	tracker.mu.Lock()
-	tracker.byID[containerID] = ContainerInfo{
-		ContainerID: containerID,
-		Name:        "/no-ip",
-		Labels:      map[string]string{},
-		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-y"}},
-	}
-	tracker.mu.Unlock()
-
-	cli := &fakeDockerClient{
-		inspectSequence: []container.InspectResponse{
-			{
-				ContainerJSONBase: &container.ContainerJSONBase{
-					ID:    containerID,
-					Name:  "/no-ip",
-					State: &container.State{Running: true},
-				},
-				Config: &container.Config{Labels: map[string]string{}},
-				NetworkSettings: &container.NetworkSettings{
-					Networks: map[string]*network.EndpointSettings{
-						".imds-0": {NetworkID: "net-y", IPAddress: "10.5.0.1"},
-					},
-				},
-			},
-		},
-	}
-
-	resp, err := findContainerByIP(context.Background(), cli, "192.168.99.99")
+	resp, err := findContainerByIP("192.168.99.99")
 	if err != nil {
 		t.Fatalf("want no error, got %v", err)
 	}
@@ -1361,28 +1319,20 @@ func TestFindContainerByIPNotFound(t *testing.T) {
 	}
 }
 
-func TestFindContainerByIPInspectError(t *testing.T) {
+func TestFindContainerByIPStaleIndex(t *testing.T) {
 	resetTracking()
 	t.Cleanup(resetTracking)
 
-	containerID := "inspect-err-789"
+	// IP is in the index but the container is no longer in byID (stale entry).
 	tracker.mu.Lock()
-	tracker.byID[containerID] = ContainerInfo{
-		ContainerID: containerID,
-		Name:        "/err-container",
-		Labels:      map[string]string{},
-		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-z"}},
-	}
+	tracker.ipToContainerID["10.0.0.1"] = "gone-container"
 	tracker.mu.Unlock()
 
-	cli := &fakeDockerClient{inspectErr: errors.New("inspect error")}
-
-	// findContainerByIP continues past inspect errors and returns nil.
-	resp, err := findContainerByIP(context.Background(), cli, "10.0.0.1")
+	resp, err := findContainerByIP("10.0.0.1")
 	if err != nil {
-		t.Fatalf("want no error (function skips failed inspects), got %v", err)
+		t.Fatalf("want no error, got %v", err)
 	}
 	if resp != nil {
-		t.Errorf("want nil response when inspect fails, got %+v", resp)
+		t.Errorf("want nil response for stale index entry, got %+v", resp)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `IPAddress`/`IPv6Address` fields to `NetworkInfo`, populated at tracking time from `ContainerInspect`
- Maintains an `ip → containerID` reverse index in `containerTracker` alongside `byID`
- Rewrites `findContainerByIP` from O(N) `ContainerInspect` calls to a single map lookup

## Test plan

- [x] All existing tests pass with `-race`
- [x] Manual test: adding and removing containers works correctly