### PR TITLE
refactor: centralize settings access in settingsStore type

### DIFF
--- a/backend/benchmark_test.go
+++ b/backend/benchmark_test.go
@@ -89,15 +89,11 @@ func BenchmarkIPLookup(b *testing.B) {
 
 // BenchmarkSettingsAccess measures performance of settings read operations
 func BenchmarkSettingsAccess(b *testing.B) {
-	settingsMutex.Lock()
-	settings = Settings{URL: "http://benchmark.example.com"}
-	settingsMutex.Unlock()
+	settings.Set(Settings{URL: "http://benchmark.example.com"})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		settingsMutex.RLock()
-		_ = settings.URL
-		settingsMutex.RUnlock()
+		_ = settings.Get().URL
 	}
 }
 

--- a/backend/handlers_echo_test.go
+++ b/backend/handlers_echo_test.go
@@ -51,14 +51,8 @@ func withTempSettingsPath(t *testing.T) {
 
 func withSettings(t *testing.T, s Settings) {
 	t.Helper()
-	settingsMutex.Lock()
-	settings = s
-	settingsMutex.Unlock()
-	t.Cleanup(func() {
-		settingsMutex.Lock()
-		settings = Settings{}
-		settingsMutex.Unlock()
-	})
+	settings.Set(s)
+	t.Cleanup(func() { settings.Set(Settings{}) })
 }
 
 func TestHello(t *testing.T) {
@@ -121,10 +115,7 @@ func TestSaveSettingsValid(t *testing.T) {
 		t.Fatalf("want status 200, got %d", rec.Code)
 	}
 
-	settingsMutex.RLock()
-	gotURL := settings.URL
-	settingsMutex.RUnlock()
-	if gotURL != "http://example.com" {
+	if gotURL := settings.Get().URL; gotURL != "http://example.com" {
 		t.Errorf("want settings URL %q, got %q", "http://example.com", gotURL)
 	}
 }
@@ -186,9 +177,7 @@ func TestSaveSettingsWithCustomIPs(t *testing.T) {
 		t.Fatalf("want status 200, got %d", rec.Code)
 	}
 
-	settingsMutex.RLock()
-	nets := settings.NetworkConfig
-	settingsMutex.RUnlock()
+	nets := settings.Get().NetworkConfig
 
 	if len(nets) != 2 {
 		t.Fatalf("want 2 network configs, got %d", len(nets))
@@ -410,16 +399,11 @@ func TestGetContainersWithData(t *testing.T) {
 	}
 	tracker.mu.Unlock()
 
-	settingsMutex.Lock()
-	settings.CustomIPs = []string{"169.254.169.254"}
-	settings.NetworkConfig = []NetworkConfig{{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254"}}
-	settingsMutex.Unlock()
-	t.Cleanup(func() {
-		settingsMutex.Lock()
-		settings.CustomIPs = nil
-		settings.NetworkConfig = nil
-		settingsMutex.Unlock()
+	settings.Set(Settings{
+		CustomIPs:     []string{"169.254.169.254"},
+		NetworkConfig: []NetworkConfig{{Name: ".imds-0", IPv4Subnet: "169.254.169.0/24", ProxyIPv4: "169.254.169.254"}},
 	})
+	t.Cleanup(func() { settings.Set(Settings{}) })
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/containers", nil)

--- a/backend/main.go
+++ b/backend/main.go
@@ -186,9 +186,25 @@ var tracker = &containerTracker{
 	ipToContainerID: make(map[string]string),
 }
 
+type settingsStore struct {
+	mu sync.RWMutex
+	v  Settings
+}
+
+func (s *settingsStore) Get() Settings {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.v
+}
+
+func (s *settingsStore) Set(v Settings) {
+	s.mu.Lock()
+	s.v = v
+	s.mu.Unlock()
+}
+
 var (
-	settings         Settings
-	settingsMutex    sync.RWMutex
+	settings         = &settingsStore{}
 	settingsPath     = "/data/settings.json"
 	proxyComposePath = "/imds-proxy-compose.yaml"
 
@@ -302,9 +318,7 @@ func main() {
 	// Reconcile networks before starting the HTTP server so the proxy is
 	// attached to all IMDS networks before the backend reports itself as ready.
 	{
-		settingsMutex.RLock()
-		netConfig := settings.NetworkConfig
-		settingsMutex.RUnlock()
+		netConfig := settings.Get().NetworkConfig
 		rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := reconcileNetworksFn(rctx, dockerClient, netConfig); err != nil {
@@ -430,9 +444,7 @@ type HTTPMessageBody struct {
 }
 
 func getSettings(ctx echo.Context) error {
-	settingsMutex.RLock()
-	defer settingsMutex.RUnlock()
-	return ctx.JSON(http.StatusOK, settings)
+	return ctx.JSON(http.StatusOK, settings.Get())
 }
 
 func saveSettings(ctx echo.Context) error {
@@ -448,9 +460,7 @@ func saveSettings(ctx echo.Context) error {
 
 	newSettings.NetworkConfig = computeNetworkConfig(newSettings.CustomIPs)
 
-	settingsMutex.Lock()
-	settings = newSettings
-	settingsMutex.Unlock()
+	settings.Set(newSettings)
 
 	// Persist settings to disk
 	if err := persistSettings(); err != nil {
@@ -493,10 +503,10 @@ func loadSettings() error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Infof("Settings file does not exist, starting with defaults")
-			settingsMutex.Lock()
-			settings.CustomIPs = []string{"169.254.169.254"}
-			settings.NetworkConfig = computeNetworkConfig(settings.CustomIPs)
-			settingsMutex.Unlock()
+			s := settings.Get()
+			s.CustomIPs = []string{"169.254.169.254"}
+			s.NetworkConfig = computeNetworkConfig(s.CustomIPs)
+			settings.Set(s)
 			return nil
 		}
 		return err
@@ -507,12 +517,8 @@ func loadSettings() error {
 		return err
 	}
 
-	settingsMutex.Lock()
-	settings = loadedSettings
-	logURL := settings.URL
-	settingsMutex.Unlock()
-
-	logger.Infof("Settings loaded from disk: url=%s", logURL)
+	settings.Set(loadedSettings)
+	logger.Infof("Settings loaded from disk: url=%s", loadedSettings.URL)
 	return nil
 }
 
@@ -522,12 +528,8 @@ func handleProxyGetSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	settingsMutex.RLock()
-	currentSettings := settings
-	settingsMutex.RUnlock()
-
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(currentSettings); err != nil {
+	if err := json.NewEncoder(w).Encode(settings.Get()); err != nil {
 		logger.Errorf("Failed to encode settings response: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -601,11 +603,7 @@ func persistSettings() error {
 		return err
 	}
 
-	settingsMutex.RLock()
-	currentSettings := settings
-	settingsMutex.RUnlock()
-
-	data, err := json.MarshalIndent(currentSettings, "", "  ")
+	data, err := json.MarshalIndent(settings.Get(), "", "  ")
 	if err != nil {
 		return err
 	}
@@ -625,9 +623,7 @@ func monitorDockerEvents() {
 
 	// If we have saved network config, reconcile networks to match.
 	// Otherwise just discover what's already there (compose defaults).
-	settingsMutex.RLock()
-	savedNetConfig := settings.NetworkConfig
-	settingsMutex.RUnlock()
+	savedNetConfig := settings.Get().NetworkConfig
 
 	if len(savedNetConfig) > 0 {
 		rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -1088,10 +1084,9 @@ func getContainers(ctx echo.Context) error {
 	tracker.mu.RLock()
 	defer tracker.mu.RUnlock()
 
-	settingsMutex.RLock()
-	netConfig := settings.NetworkConfig
-	customIPs := settings.CustomIPs
-	settingsMutex.RUnlock()
+	s := settings.Get()
+	netConfig := s.NetworkConfig
+	customIPs := s.CustomIPs
 
 	containerList := make([]ContainerInfo, 0, len(tracker.byID))
 	for _, info := range tracker.byID {

--- a/backend/settings_test.go
+++ b/backend/settings_test.go
@@ -61,10 +61,8 @@ func TestLoadSettingsValidJSON(t *testing.T) {
 		t.Fatalf("want no error, got %v", err)
 	}
 
-	settingsMutex.RLock()
-	defer settingsMutex.RUnlock()
-	if settings.URL != "http://example.com" {
-		t.Fatalf("want URL to be loaded, got %q", settings.URL)
+	if settings.Get().URL != "http://example.com" {
+		t.Fatalf("want URL to be loaded, got %q", settings.Get().URL)
 	}
 }
 
@@ -74,9 +72,7 @@ func TestPersistSettingsWritesFile(t *testing.T) {
 	settingsPath = filepath.Join(tempDir, "settings.json")
 	defer func() { settingsPath = originalPath }()
 
-	settingsMutex.Lock()
-	settings = Settings{URL: "http://example.com"}
-	settingsMutex.Unlock()
+	settings.Set(Settings{URL: "http://example.com"})
 
 	if err := persistSettings(); err != nil {
 		t.Fatalf("want no error, got %v", err)
@@ -99,14 +95,8 @@ func TestPersistSettingsWriteError(t *testing.T) {
 	settingsPath = tempDir
 	defer func() { settingsPath = originalPath }()
 
-	settingsMutex.Lock()
-	settings = Settings{URL: "http://write-error.example.com"}
-	settingsMutex.Unlock()
-	defer func() {
-		settingsMutex.Lock()
-		settings = Settings{}
-		settingsMutex.Unlock()
-	}()
+	settings.Set(Settings{URL: "http://write-error.example.com"})
+	defer func() { settings.Set(Settings{}) }()
 
 	if err := persistSettings(); err == nil {
 		t.Fatal("want error when writing to a directory path, got nil")
@@ -119,14 +109,8 @@ func TestPersistSettingsNestedDir(t *testing.T) {
 	settingsPath = filepath.Join(tempDir, "nested", "deep", "settings.json")
 	defer func() { settingsPath = originalPath }()
 
-	settingsMutex.Lock()
-	settings = Settings{URL: "http://nested.example.com"}
-	settingsMutex.Unlock()
-	defer func() {
-		settingsMutex.Lock()
-		settings = Settings{}
-		settingsMutex.Unlock()
-	}()
+	settings.Set(Settings{URL: "http://nested.example.com"})
+	defer func() { settings.Set(Settings{}) }()
 
 	if err := persistSettings(); err != nil {
 		t.Fatalf("persistSettings() with nested dir returned error: %v", err)

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -447,9 +447,7 @@ func TestConcurrentSettingsAccess(t *testing.T) {
 			defer wg.Done()
 
 			for j := 0; j < numOperations; j++ {
-				settingsMutex.RLock()
-				_ = settings.URL
-				settingsMutex.RUnlock()
+				_ = settings.Get().URL
 			}
 		}()
 	}
@@ -460,9 +458,9 @@ func TestConcurrentSettingsAccess(t *testing.T) {
 			defer wg.Done()
 
 			for j := 0; j < numOperations; j++ {
-				settingsMutex.Lock()
-				settings.URL = fmt.Sprintf("http://example.com/%d-%d", id, j)
-				settingsMutex.Unlock()
+				s := settings.Get()
+				s.URL = fmt.Sprintf("http://example.com/%d-%d", id, j)
+				settings.Set(s)
 			}
 		}(i)
 	}
@@ -982,11 +980,9 @@ func TestStressRapidSettingsChanges(t *testing.T) {
 
 			for j := 0; j < numUpdates; j++ {
 				// Write settings
-				settingsMutex.Lock()
-				settings = Settings{
+				settings.Set(Settings{
 					URL: fmt.Sprintf("http://test-%d-%d.example.com", id, j),
-				}
-				settingsMutex.Unlock()
+				})
 
 				if err := persistSettings(); err != nil {
 					// Some errors expected due to concurrent writes
@@ -1006,10 +1002,7 @@ func TestStressRapidSettingsChanges(t *testing.T) {
 	if err != nil {
 		t.Logf("Final settings load returned error: %v (acceptable)", err)
 	} else {
-		settingsMutex.RLock()
-		finalURL := settings.URL
-		settingsMutex.RUnlock()
-		t.Logf("Final settings URL: %s", finalURL)
+		t.Logf("Final settings URL: %s", settings.Get().URL)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces the package-level `settings Settings` + `settingsMutex sync.RWMutex` pair with a single `settingsStore` type
- `Get()` and `Set()` methods encapsulate the lock, eliminating repeated inline lock/copy/unlock at every call site
- All production code and tests updated to use the new API

## Test plan

- [x] All tests pass with `-race`
- [x] Manual test: settings save/load works correctly